### PR TITLE
feat(submit): add submit_options for scheduler submit command arguments

### DIFF
--- a/src/hpc/config.py
+++ b/src/hpc/config.py
@@ -93,16 +93,24 @@ class SyncConfig(BaseModel):
     pull_dir: str = ""
 
 
+def _validate_submit_option(opt: str) -> None:
+    """Reject submit options containing shell special characters."""
+    if bad := SHELL_SPECIAL & set(opt):
+        raise ValueError(f"Shell special characters not allowed in submit_options: {bad}")
+
+
 class SlurmConfig(BaseModel):
     """Slurm job configuration"""
 
     options: dict[str, str | int] = {}
+    submit_options: list[str] = []
 
 
 class PjmConfig(BaseModel):
     """PJM job configuration"""
 
     options: list[list[str]] = []
+    submit_options: list[str] = []
 
 
 class HpcConfig(BaseModel):
@@ -153,8 +161,14 @@ class ConfigManager:
             cluster=ClusterConfig(**data["cluster"]),
             env=EnvConfig(**data.get("env", {})),
             sync=SyncConfig(**data.get("sync", {})),
-            slurm=SlurmConfig(options=data.get("slurm", {}).get("options", {})),
-            pjm=PjmConfig(options=data.get("pjm", {}).get("options", [])),
+            slurm=SlurmConfig(
+                options=data.get("slurm", {}).get("options", {}),
+                submit_options=data.get("slurm", {}).get("submit_options", []),
+            ),
+            pjm=PjmConfig(
+                options=data.get("pjm", {}).get("options", []),
+                submit_options=data.get("pjm", {}).get("submit_options", []),
+            ),
         )
 
     def generate_template(self, path: Path) -> None:

--- a/src/hpc/config.py
+++ b/src/hpc/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import tomli_w
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 # str: command without args, dict: {cmd: args}
 SetupItem = str | dict[str, str | list[str]]
@@ -93,10 +93,14 @@ class SyncConfig(BaseModel):
     pull_dir: str = ""
 
 
-def _validate_submit_option(opt: str) -> None:
+def _validate_submit_options(opts: list[str]) -> list[str]:
     """Reject only structurally unsafe characters in submit options."""
-    if "\n" in opt or "\x00" in opt:
-        raise ValueError("Newline and NUL characters are not allowed in submit_options")
+    for opt in opts:
+        if "\n" in opt or "\x00" in opt:
+            raise ValueError(
+                "Newline and NUL characters are not allowed in submit_options"
+            )
+    return opts
 
 
 class SlurmConfig(BaseModel):
@@ -105,12 +109,22 @@ class SlurmConfig(BaseModel):
     options: dict[str, str | int] = {}
     submit_options: list[str] = []
 
+    @field_validator("submit_options")
+    @classmethod
+    def check_submit_options(cls, v: list[str]) -> list[str]:
+        return _validate_submit_options(v)
+
 
 class PjmConfig(BaseModel):
     """PJM job configuration"""
 
     options: list[list[str]] = []
     submit_options: list[str] = []
+
+    @field_validator("submit_options")
+    @classmethod
+    def check_submit_options(cls, v: list[str]) -> list[str]:
+        return _validate_submit_options(v)
 
 
 class HpcConfig(BaseModel):
@@ -193,7 +207,7 @@ class ConfigManager:
                     "mem": "32G",
                     "gpus": 1,
                     "account": "myaccount",
-                }
+                },
             },
         }
         with open(path, "wb") as f:

--- a/src/hpc/config.py
+++ b/src/hpc/config.py
@@ -94,9 +94,9 @@ class SyncConfig(BaseModel):
 
 
 def _validate_submit_option(opt: str) -> None:
-    """Reject submit options containing shell special characters."""
-    if bad := SHELL_SPECIAL & set(opt):
-        raise ValueError(f"Shell special characters not allowed in submit_options: {bad}")
+    """Reject only structurally unsafe characters in submit options."""
+    if "\n" in opt or "\x00" in opt:
+        raise ValueError("Newline and NUL characters are not allowed in submit_options")
 
 
 class SlurmConfig(BaseModel):
@@ -186,6 +186,7 @@ class ConfigManager:
                 "ignore_push": [".hpc"],
             },
             "slurm": {
+                "submit_options": [],
                 "options": {
                     "partition": "gpu",
                     "time": "02:00:00",

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from jinja2 import Template
 
-from .config import HpcConfig
+from .config import HpcConfig, _validate_submit_option
 from .ssh import SSHManager
 from .run import RunConfig
 from .scheduler import JobStatus, get_scheduler
@@ -46,6 +46,17 @@ class JobManager:
         self.ssh_manager = ssh_manager
         self.config = config
         self.scheduler = get_scheduler(config.cluster.scheduler)
+
+    def _get_submit_options(self) -> list[str]:
+        """Get validated submit command options from config."""
+        opts = (
+            self.config.pjm.submit_options
+            if self.config.cluster.scheduler == "pjm"
+            else self.config.slurm.submit_options
+        )
+        for opt in opts:
+            _validate_submit_option(opt)
+        return opts
 
     def _build_directives(
         self, options: dict | list, job_name: str | None = None
@@ -107,7 +118,10 @@ class JobManager:
         self.ssh_manager.run_command("tee", [script_path], input_text=script)
 
         cmd = self.scheduler.submit_cmd()
-        result = self.ssh_manager.run_command(cmd[0], cmd[1:] + [script_path])
+        submit_options = self._get_submit_options()
+        result = self.ssh_manager.run_command(
+            cmd[0], cmd[1:] + submit_options + [script_path]
+        )
         return self.scheduler.parse_job_id(result.stdout)
 
     def submit_job(self, cmd: str) -> str:
@@ -132,8 +146,9 @@ class JobManager:
             cmd=cmd,
         )
         submit_cmd = self.scheduler.submit_cmd()
+        submit_options = self._get_submit_options()
         result = self.ssh_manager.run_command(
-            submit_cmd[0], submit_cmd[1:], input_text=script
+            submit_cmd[0], submit_cmd[1:] + submit_options, input_text=script
         )
         return self.scheduler.parse_job_id(result.stdout)
 

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from jinja2 import Template
 
-from .config import HpcConfig, _validate_submit_option
+from .config import HpcConfig
 from .ssh import SSHManager
 from .run import RunConfig
 from .scheduler import JobStatus, get_scheduler
@@ -48,15 +48,12 @@ class JobManager:
         self.scheduler = get_scheduler(config.cluster.scheduler)
 
     def _get_submit_options(self) -> list[str]:
-        """Get validated submit command options from config."""
-        opts = (
+        """Get submit command options from config."""
+        return (
             self.config.pjm.submit_options
             if self.config.cluster.scheduler == "pjm"
             else self.config.slurm.submit_options
         )
-        for opt in opts:
-            _validate_submit_option(opt)
-        return opts
 
     def _build_directives(
         self, options: dict | list, job_name: str | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,6 +84,14 @@ class TestSlurmConfig:
         config = SlurmConfig(submit_options=["--export=ALL"])
         assert config.submit_options == ["--export=ALL"]
 
+    def test_slurm_config_rejects_newline_in_submit_options(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            SlurmConfig(submit_options=["--opt\nmalicious"])
+
+    def test_slurm_config_rejects_nul_in_submit_options(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            SlurmConfig(submit_options=["--opt\x00malicious"])
+
 
 class TestPjmConfig:
     def test_pjm_config_defaults(self):
@@ -94,6 +102,10 @@ class TestPjmConfig:
     def test_pjm_config_with_submit_options(self):
         config = PjmConfig(submit_options=["--no-check-directory"])
         assert config.submit_options == ["--no-check-directory"]
+
+    def test_pjm_config_rejects_newline_in_submit_options(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            PjmConfig(submit_options=["--opt\nmalicious"])
 
 
 class TestHpcConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -156,6 +156,25 @@ submit_options = ["--no-check-directory"]
         assert config.pjm.submit_options == ["--no-check-directory"]
         assert config.pjm.options == [["-L", "node=12"], ["-s"]]
 
+    def test_load_slurm_config_with_submit_options(self, temp_dir):
+        config_path = temp_dir / "hpc.toml"
+        config_path.write_text("""
+[cluster]
+host = "myhpc"
+workdir = "/scratch/user/proj"
+
+[slurm]
+submit_options = ["--export=ALL"]
+
+[slurm.options]
+partition = "gpu"
+""")
+        manager = ConfigManager()
+        config = manager.load_config(config_path)
+
+        assert config.slurm.submit_options == ["--export=ALL"]
+        assert config.slurm.options["partition"] == "gpu"
+
     def test_load_config_file_not_found(self):
         manager = ConfigManager()
         with pytest.raises(FileNotFoundError):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from hpc.config import (
     ClusterConfig,
     EnvConfig,
     SlurmConfig,
+    PjmConfig,
     HpcConfig,
     ConfigManager,
     find_config,
@@ -70,6 +71,7 @@ class TestSlurmConfig:
     def test_slurm_config_default_options(self):
         config = SlurmConfig()
         assert config.options == {}
+        assert config.submit_options == []
 
     def test_slurm_config_with_options(self):
         config = SlurmConfig(
@@ -77,6 +79,21 @@ class TestSlurmConfig:
         )
         assert config.options["partition"] == "gpu"
         assert config.options["gpus"] == 1
+
+    def test_slurm_config_with_submit_options(self):
+        config = SlurmConfig(submit_options=["--export=ALL"])
+        assert config.submit_options == ["--export=ALL"]
+
+
+class TestPjmConfig:
+    def test_pjm_config_defaults(self):
+        config = PjmConfig()
+        assert config.options == []
+        assert config.submit_options == []
+
+    def test_pjm_config_with_submit_options(self):
+        config = PjmConfig(submit_options=["--no-check-directory"])
+        assert config.submit_options == ["--no-check-directory"]
 
 
 class TestHpcConfig:
@@ -120,6 +137,24 @@ gpus = 1
         assert config.slurm.options["time"] == "02:00:00"
         assert config.slurm.options["mem"] == "32G"
         assert config.slurm.options["gpus"] == 1
+
+    def test_load_pjm_config_with_submit_options(self, temp_dir):
+        config_path = temp_dir / "hpc.toml"
+        config_path.write_text("""
+[cluster]
+host = "myhpc"
+workdir = "/scratch/user/proj"
+scheduler = "pjm"
+
+[pjm]
+options = [["-L", "node=12"], ["-s"]]
+submit_options = ["--no-check-directory"]
+""")
+        manager = ConfigManager()
+        config = manager.load_config(config_path)
+
+        assert config.pjm.submit_options == ["--no-check-directory"]
+        assert config.pjm.options == [["-L", "node=12"], ["-s"]]
 
     def test_load_config_file_not_found(self):
         manager = ConfigManager()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -58,10 +58,11 @@ class TestJobManagerSubmit:
         assert call_args.args[0] == "sbatch"
         assert "--parsable" in call_args.args[1]
 
-
     def test_submit_job_includes_pjm_submit_options(self, mock_ssh_manager):
         config = HpcConfig(
-            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
             env=EnvConfig(),
             pjm=PjmConfig(
                 options=[["-L", "node=12"]],
@@ -77,18 +78,6 @@ class TestJobManagerSubmit:
         call_args = mock_ssh_manager.run_command.call_args
         assert call_args.args[0] == "pjsub"
         assert "--no-check-directory" in call_args.args[1]
-
-    def test_submit_job_rejects_newline_in_submit_options(self, mock_ssh_manager):
-        config = HpcConfig(
-            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
-            env=EnvConfig(),
-            pjm=PjmConfig(submit_options=["--opt\nmalicious"]),
-        )
-        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
-        mock_ssh_manager.run_command.return_value = MagicMock(stdout="")
-
-        with pytest.raises(ValueError, match="Newline and NUL"):
-            manager.submit_job("python train.py")
 
     def test_submit_job_includes_slurm_submit_options(self, mock_ssh_manager):
         config = HpcConfig(
@@ -108,10 +97,11 @@ class TestJobManagerSubmit:
         assert "--parsable" in call_args.args[1]
         assert "--export=ALL" in call_args.args[1]
 
-
     def test_submit_run_includes_pjm_submit_options(self, mock_ssh_manager):
         config = HpcConfig(
-            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
             env=EnvConfig(),
             pjm=PjmConfig(
                 options=[["-L", "node=12"]],

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -7,7 +7,7 @@ import pytest
 
 from hpc.job import JobManager, JobStatus
 from hpc.ssh import SSHManager
-from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig
+from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig, PjmConfig
 
 
 @pytest.fixture
@@ -57,6 +57,56 @@ class TestJobManagerSubmit:
         call_args = mock_ssh_manager.run_command.call_args
         assert call_args.args[0] == "sbatch"
         assert "--parsable" in call_args.args[1]
+
+
+    def test_submit_job_includes_pjm_submit_options(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
+            env=EnvConfig(),
+            pjm=PjmConfig(
+                options=[["-L", "node=12"]],
+                submit_options=["--no-check-directory"],
+            ),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout="[INFO] PJM 0000 pjsub Job 12345678 submitted.\n"
+        )
+
+        manager.submit_job("python train.py")
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "pjsub"
+        assert "--no-check-directory" in call_args.args[1]
+
+    def test_submit_job_rejects_shell_injection_in_submit_options(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
+            env=EnvConfig(),
+            pjm=PjmConfig(submit_options=["--no-check-directory; rm -rf /"]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="")
+
+        with pytest.raises(ValueError, match="Shell special characters"):
+            manager.submit_job("python train.py")
+
+    def test_submit_job_includes_slurm_submit_options(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
+            env=EnvConfig(),
+            slurm=SlurmConfig(
+                options={"partition": "gpu"},
+                submit_options=["--export=ALL"],
+            ),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
+
+        manager.submit_job("python train.py")
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "sbatch"
+        assert "--parsable" in call_args.args[1]
+        assert "--export=ALL" in call_args.args[1]
 
 
 class TestJobManagerStatus:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -78,16 +78,16 @@ class TestJobManagerSubmit:
         assert call_args.args[0] == "pjsub"
         assert "--no-check-directory" in call_args.args[1]
 
-    def test_submit_job_rejects_shell_injection_in_submit_options(self, mock_ssh_manager):
+    def test_submit_job_rejects_newline_in_submit_options(self, mock_ssh_manager):
         config = HpcConfig(
             cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
             env=EnvConfig(),
-            pjm=PjmConfig(submit_options=["--no-check-directory; rm -rf /"]),
+            pjm=PjmConfig(submit_options=["--opt\nmalicious"]),
         )
         manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
         mock_ssh_manager.run_command.return_value = MagicMock(stdout="")
 
-        with pytest.raises(ValueError, match="Shell special characters"):
+        with pytest.raises(ValueError, match="Newline and NUL"):
             manager.submit_job("python train.py")
 
     def test_submit_job_includes_slurm_submit_options(self, mock_ssh_manager):
@@ -103,6 +103,51 @@ class TestJobManagerSubmit:
         mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
 
         manager.submit_job("python train.py")
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "sbatch"
+        assert "--parsable" in call_args.args[1]
+        assert "--export=ALL" in call_args.args[1]
+
+
+    def test_submit_run_includes_pjm_submit_options(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"),
+            env=EnvConfig(),
+            pjm=PjmConfig(
+                options=[["-L", "node=12"]],
+                submit_options=["--no-check-directory"],
+            ),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout="[INFO] PJM 0000 pjsub Job 12345678 submitted.\n"
+        )
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="python train.py", status="pending")
+        manager.submit_run(run)
+
+        # Last run_command call is the submit
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "pjsub"
+        assert "--no-check-directory" in call_args.args[1]
+
+    def test_submit_run_includes_slurm_submit_options(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
+            env=EnvConfig(),
+            slurm=SlurmConfig(
+                options={"partition": "gpu"},
+                submit_options=["--export=ALL"],
+            ),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="python train.py", status="pending")
+        manager.submit_run(run)
+
         call_args = mock_ssh_manager.run_command.call_args
         assert call_args.args[0] == "sbatch"
         assert "--parsable" in call_args.args[1]


### PR DESCRIPTION
Allow configuring command-line options passed to the submit command (e.g. pjsub --no-check-directory) via submit_options in [slurm] or [pjm] config sections. Includes shell special character validation.