### PR TITLE
feat(job-output): add --follow flag for live log streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Accepts either run_id or job_id.
 hpc job-output 12345678
 ```
 
+Pass `--follow` / `-f` to stream the output of a running job in real time
+(equivalent to `tail -F` on the remote output file). Combine with `--error` /
+`-e` to follow stderr instead of stdout. For terminal-state jobs the command
+prints the final output and exits.
+
+```bash
+hpc job-output -f 12345678
+hpc job-output -f -e 12345678
+```
+
 ### `hpc wait`
 
 Waits for a run to complete.

--- a/src/hpc/cli.py
+++ b/src/hpc/cli.py
@@ -344,6 +344,12 @@ def job_output(
     error: bool = typer.Option(
         False, "--error", "-e", help="Show stderr instead of stdout"
     ),
+    follow: bool = typer.Option(
+        False,
+        "--follow",
+        "-f",
+        help="Stream output as the job runs (tail -F equivalent)",
+    ),
     config: ConfigOption = None,
 ):
     """Show job output (accepts run_id or job_id)"""
@@ -368,6 +374,12 @@ def job_output(
 
     ssh = SSHManager(host=hpc_config.cluster.host)
     job_manager = JobManager(ssh_manager=ssh, config=hpc_config)
+
+    if follow:
+        rc = job_manager.tail_job_output(run.run_id, run.job_id, error=error)
+        if rc != 0:
+            raise typer.Exit(rc)
+        return
 
     output = job_manager.get_job_output(run.run_id, run.job_id, error=error)
     print(output, end="")

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -178,6 +178,36 @@ class JobManager:
                         return f"Job {job_id} is {status.value}. Output file not yet available.\n"
             raise
 
+    def tail_job_output(self, run_id: str, job_id: str, error: bool = False) -> int:
+        """Stream job output via `tail -F` (equivalent to live tailing).
+
+        For terminal-state jobs, falls back to `get_job_output` because no
+        further output is coming and `tail -F` would otherwise spin forever
+        on a missing file. For active or unknown-status jobs, runs `tail -F`
+        which retries internally until the output file appears.
+        """
+        from .ssh import SSHError
+
+        try:
+            status = self.get_job_status(job_id)
+        except SSHError:
+            status = None  # status unknown; fall through to tail -F
+
+        terminal_states = {
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.TIMEOUT,
+        }
+        if status in terminal_states:
+            print(self.get_job_output(run_id, job_id, error=error), end="")
+            return 0
+
+        workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
+        ext = "err" if error else "out"
+        output_path = f"{workdir}/.hpc/runs/{run_id}/job-{job_id}.{ext}"
+        return self.ssh_manager.run_streaming("tail", ["-F", output_path])
+
     def wait_for_job(
         self,
         job_id: str,

--- a/src/hpc/ssh.py
+++ b/src/hpc/ssh.py
@@ -128,3 +128,25 @@ class SSHManager:
             stdout=result.stdout,
             stderr=result.stderr,
         )
+
+    def run_streaming(
+        self,
+        cmd: str,
+        args: Optional[list[str]] = None,
+    ) -> int:
+        """Execute command on remote host, streaming stdout/stderr to terminal.
+
+        Mirrors run_command's argument shape and shell-injection defenses, but
+        does not capture output — the remote process writes directly to the
+        local terminal. Use for long-running, output-producing commands such
+        as `tail -F`. Returns the SSH process exit code; does not raise on
+        non-zero exit.
+        """
+        if args is None:
+            args = []
+        self._validate_command_name(cmd)
+        quoted_parts = [shlex.quote(cmd), *[shlex.quote(arg) for arg in args]]
+        command = " ".join(quoted_parts)
+
+        result = subprocess.run(self._build_ssh_command(command))
+        return result.returncode

--- a/src/hpc/ssh.py
+++ b/src/hpc/ssh.py
@@ -141,6 +141,11 @@ class SSHManager:
         local terminal. Use for long-running, output-producing commands such
         as `tail -F`. Returns the SSH process exit code; does not raise on
         non-zero exit.
+
+        On Ctrl-C, both Python and the SSH client receive SIGINT (foreground
+        process group). subprocess.run kills + reaps the child and re-raises
+        KeyboardInterrupt; we convert that to the conventional shell exit
+        code 130 so callers can propagate cleanly without aborting.
         """
         if args is None:
             args = []
@@ -148,5 +153,8 @@ class SSHManager:
         quoted_parts = [shlex.quote(cmd), *[shlex.quote(arg) for arg in args]]
         command = " ".join(quoted_parts)
 
-        result = subprocess.run(self._build_ssh_command(command))
+        try:
+            result = subprocess.run(self._build_ssh_command(command))
+        except KeyboardInterrupt:
+            return 130
         return result.returncode

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,3 +140,70 @@ def test_init_does_not_walk_up(cli_runner, temp_dir, monkeypatch):
     result = cli_runner.invoke(app, ["init"])
     assert result.exit_code == 0
     assert (child / "hpc.toml").exists()
+
+
+def test_job_output_follow_in_help(cli_runner):
+    result = cli_runner.invoke(app, ["job-output", "--help"])
+    assert result.exit_code == 0
+    assert "--follow" in result.stdout
+    assert "-f" in result.stdout
+
+
+def _setup_run_meta(temp_dir, run_id="r1", job_id="12345678"):
+    """Write hpc.toml + a fake run meta so job-output can resolve the run."""
+    (temp_dir / "hpc.toml").write_text("[cluster]\nhost = 'test'\nworkdir = '/tmp'\n")
+    runs_dir = temp_dir / ".hpc" / "runs" / run_id
+    runs_dir.mkdir(parents=True)
+    (runs_dir / "meta.toml").write_text(
+        f'run_id = "{run_id}"\n'
+        f'cmd = "echo hi"\n'
+        f'status = "running"\n'
+        f'job_id = "{job_id}"\n'
+    )
+
+
+def test_job_output_follow_passes_error_flag(cli_runner, temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    with patch("hpc.cli.JobManager") as mock_job_cls:
+        mock_job = MagicMock()
+        mock_job.tail_job_output.return_value = 0
+        mock_job_cls.return_value = mock_job
+
+        result = cli_runner.invoke(app, ["job-output", "-f", "-e", "r1"])
+        assert result.exit_code == 0
+        mock_job.tail_job_output.assert_called_once_with("r1", "12345678", error=True)
+        mock_job.get_job_output.assert_not_called()
+
+
+def test_job_output_follow_propagates_exit_code(cli_runner, temp_dir, monkeypatch):
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    with patch("hpc.cli.JobManager") as mock_job_cls:
+        mock_job = MagicMock()
+        mock_job.tail_job_output.return_value = 130  # Ctrl-C
+        mock_job_cls.return_value = mock_job
+
+        result = cli_runner.invoke(app, ["job-output", "-f", "r1"])
+        assert result.exit_code == 130
+
+
+def test_job_output_without_follow_uses_get_job_output(
+    cli_runner, temp_dir, monkeypatch
+):
+    """Regression guard: --follow=False must still use the cat-based path."""
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    with patch("hpc.cli.JobManager") as mock_job_cls:
+        mock_job = MagicMock()
+        mock_job.get_job_output.return_value = "static output\n"
+        mock_job_cls.return_value = mock_job
+
+        result = cli_runner.invoke(app, ["job-output", "r1"])
+        assert result.exit_code == 0
+        mock_job.get_job_output.assert_called_once_with("r1", "12345678", error=False)
+        mock_job.tail_job_output.assert_not_called()
+        assert "static output" in result.stdout

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hpc.job import JobManager, JobStatus
-from hpc.ssh import SSHManager
+from hpc.ssh import SSHManager, SSHError
 from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig, PjmConfig
 
 
@@ -204,3 +204,80 @@ class TestJobManagerTemplate:
         assert "cd /scratch/user/proj/runs/bench1" in script
         # Output paths still use base workdir
         assert "--output=/scratch/user/proj/.hpc/runs/test_run" in script
+
+
+class TestJobManagerTailJobOutput:
+    def _running_status(self):
+        return MagicMock(stdout="RUNNING\n")
+
+    def _completed_status(self):
+        return MagicMock(stdout="COMPLETED\n")
+
+    def test_tail_job_output_active_uses_tail_F(self, mock_ssh_manager, sample_config):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = self._running_status()
+        mock_ssh_manager.run_streaming.return_value = 0
+
+        rc = manager.tail_job_output("run_id", "12345678")
+
+        assert rc == 0
+        mock_ssh_manager.run_streaming.assert_called_once_with(
+            "tail",
+            ["-F", "/scratch/user/proj/.hpc/runs/run_id/job-12345678.out"],
+        )
+
+    def test_tail_job_output_terminal_falls_back_to_get_job_output(
+        self, mock_ssh_manager, sample_config, capsys
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        # First call: status=COMPLETED (terminal). Second call: cat output.
+        mock_ssh_manager.run_command.side_effect = [
+            self._completed_status(),
+            MagicMock(stdout="final job output\n"),
+        ]
+
+        rc = manager.tail_job_output("run_id", "12345678")
+
+        assert rc == 0
+        mock_ssh_manager.run_streaming.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.out == "final job output\n"
+
+    def test_tail_job_output_unknown_status_streams(
+        self, mock_ssh_manager, sample_config
+    ):
+        """SSHError on get_job_status falls through to tail -F (safe-side default)."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = SSHError("transient ssh failure")
+        mock_ssh_manager.run_streaming.return_value = 0
+
+        rc = manager.tail_job_output("run_id", "12345678")
+
+        assert rc == 0
+        mock_ssh_manager.run_streaming.assert_called_once()
+
+    def test_tail_job_output_error_flag_uses_err_extension(
+        self, mock_ssh_manager, sample_config
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = self._running_status()
+        mock_ssh_manager.run_streaming.return_value = 0
+
+        manager.tail_job_output("run_id", "12345678", error=True)
+
+        call_args = mock_ssh_manager.run_streaming.call_args
+        assert call_args.args[0] == "tail"
+        assert call_args.args[1] == [
+            "-F",
+            "/scratch/user/proj/.hpc/runs/run_id/job-12345678.err",
+        ]
+
+    def test_tail_job_output_returns_streaming_exit_code(
+        self, mock_ssh_manager, sample_config
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = self._running_status()
+        mock_ssh_manager.run_streaming.return_value = 130  # Ctrl-C exit code
+
+        rc = manager.tail_job_output("run_id", "12345678")
+        assert rc == 130

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -131,3 +131,57 @@ class TestSSHManagerControlMaster:
             args_str = " ".join(call_args)
             assert "ControlMaster" in args_str
             assert "ControlPath" in args_str
+
+
+class TestSSHManagerRunStreaming:
+    def test_run_streaming_does_not_capture_output(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            manager.run_streaming("tail", ["-F", "/some/file"])
+            call_kwargs = mock_run.call_args[1]
+            assert "capture_output" not in call_kwargs
+
+    def test_run_streaming_returns_exit_code(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=130)
+            assert manager.run_streaming("tail", ["-F", "/path"]) == 130
+
+    def test_run_streaming_validates_command(self):
+        manager = SSHManager(host="myhpc")
+        with pytest.raises(ValueError):
+            manager.run_streaming("tail; rm -rf /", ["-F", "/path"])
+
+    def test_run_streaming_quotes_args(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            manager.run_streaming("tail", ["-F", "/path with space/file"])
+            remote_cmd = mock_run.call_args[0][0][-1]
+            assert "'/path with space/file'" in remote_cmd
+
+    def test_run_streaming_includes_control_master(self):
+        manager = SSHManager(host="myhpc", use_control_master=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            manager.run_streaming("tail", ["-F", "/path"])
+            args_str = " ".join(mock_run.call_args[0][0])
+            assert "ControlMaster" in args_str
+            assert "ControlPath" in args_str
+
+    def test_run_streaming_builds_tail_command(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            manager.run_streaming("tail", ["-F", "/path/file"])
+            remote_cmd = mock_run.call_args[0][0][-1]
+            assert remote_cmd == "tail -F /path/file"
+
+    def test_run_streaming_no_args(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            manager.run_streaming("hostname")
+            remote_cmd = mock_run.call_args[0][0][-1]
+            assert remote_cmd == "hostname"

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -185,3 +185,11 @@ class TestSSHManagerRunStreaming:
             manager.run_streaming("hostname")
             remote_cmd = mock_run.call_args[0][0][-1]
             assert remote_cmd == "hostname"
+
+    def test_run_streaming_returns_130_on_keyboard_interrupt(self):
+        """Ctrl-C during streaming: subprocess.run re-raises KeyboardInterrupt;
+        we convert to the conventional SIGINT exit code so Typer does not abort.
+        """
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run", side_effect=KeyboardInterrupt):
+            assert manager.run_streaming("tail", ["-F", "/path"]) == 130


### PR DESCRIPTION
## Summary

- Add `--follow` / `-f` to `hpc job-output` that streams the running job's stdout (or stderr with `--error`) over SSH using `tail -F`.
- Add `SSHManager.run_streaming` for non-capturing SSH command execution; mirrors `run_command`'s shell-injection defenses (command-name validation + `shlex.quote`).
- Add `JobManager.tail_job_output` with status-aware dispatch: terminal-state jobs fall back to the existing `cat` path so a missing output file surfaces the same error as before, instead of `tail -F` spinning forever.
- Convert `KeyboardInterrupt` during streaming to exit code 130 so Ctrl-C propagates cleanly through Typer.

## Test plan

- [x] `uv run pytest` — 136 tests pass (was 119 before this PR; 17 new).
- [x] `uv run ruff check src tests` clean.
- [x] `uv run ruff format --check src tests` clean.
- [x] `uv run pyright src/hpc/` 0 errors.
- [x] Live smoke on a real HPC cluster: `hpc job-output -f <id>` → Ctrl-C → confirm no residual remote `tail` (deferred probe; the conventional SSH-SIGINT propagation path is what is implemented).

## Follow-up

- #8 — `scheduler.parse_status` mis-classifies empty status output as `FAILED`; surfaced by codex-review on this branch but pre-existing in the scheduler layer.

Closes #4