### PR TITLE
fix(scheduler): aggregate Slurm sacct rows for array job wait

### DIFF
--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -45,7 +45,19 @@ class Slurm(Scheduler):
         # -X suppresses jobsteps so each row is one allocation; for an array
         # job this yields exactly one row per task, which the aggregation
         # below relies on.
-        return ["sacct", "-j", job_id, "--format=State", "--noheader", "-X"]
+        # State%30 widens the column past sacct's 10-char default so that
+        # long state names (CONFIGURING, OUT_OF_MEMORY, ...) are not
+        # truncated to "CONFIGURI+" / "OUT_OF_ME+" — the truncation marker
+        # would survive rstrip("+") as a prefix that misses _STATUS_MAP and
+        # falls back to FAILED, exiting wait_for_job prematurely.
+        return [
+            "sacct",
+            "-j",
+            job_id,
+            "--format=State%30",
+            "--noheader",
+            "-X",
+        ]
 
     def parse_status(self, output: str) -> JobStatus:
         # Aggregate over all rows so an array job is reported as terminal

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -64,9 +64,14 @@ class Slurm(Scheduler):
         # only once every task is terminal. A single non-terminal task in
         # the set must keep the aggregate non-terminal to prevent
         # wait_for_job from exiting prematurely.
-        lines = [
-            ln.strip().rstrip("+") for ln in output.strip().splitlines() if ln.strip()
-        ]
+        # Normalize each row to its first whitespace-separated token so
+        # extended forms such as "CANCELLED by 12345" (emitted at the
+        # widened State%30 column) reduce to "CANCELLED".
+        lines = []
+        for ln in output.strip().splitlines():
+            tokens = ln.split()
+            if tokens:
+                lines.append(tokens[0].rstrip("+"))
         if not lines:
             return JobStatus.FAILED
         statuses = [_STATUS_MAP.get(s, JobStatus.FAILED) for s in lines]

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -42,12 +42,32 @@ class Slurm(Scheduler):
         return output.strip()
 
     def status_cmd(self, job_id: str) -> list[str]:
-        return ["sacct", "-j", job_id, "--format=State", "--noheader"]
+        # -X suppresses jobsteps so each row is one allocation; for an array
+        # job this yields exactly one row per task, which the aggregation
+        # below relies on.
+        return ["sacct", "-j", job_id, "--format=State", "--noheader", "-X"]
 
     def parse_status(self, output: str) -> JobStatus:
-        lines = output.strip().splitlines()
-        status_str = lines[0].strip().rstrip("+") if lines else ""
-        return _STATUS_MAP.get(status_str, JobStatus.FAILED)
+        # Aggregate over all rows so an array job is reported as terminal
+        # only once every task is terminal. A single non-terminal task in
+        # the set must keep the aggregate non-terminal to prevent
+        # wait_for_job from exiting prematurely.
+        lines = [
+            ln.strip().rstrip("+") for ln in output.strip().splitlines() if ln.strip()
+        ]
+        if not lines:
+            return JobStatus.FAILED
+        statuses = [_STATUS_MAP.get(s, JobStatus.FAILED) for s in lines]
+        for status in (
+            JobStatus.RUNNING,
+            JobStatus.PENDING,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.TIMEOUT,
+        ):
+            if status in statuses:
+                return status
+        return JobStatus.COMPLETED
 
 
 class PJM(Scheduler):
@@ -94,13 +114,33 @@ class PJM(Scheduler):
         return self._STATUS_MAP.get(status_str, JobStatus.FAILED)
 
 
+# Slurm job state strings as reported by `sacct`. Unknown states fall back
+# to FAILED at the call site so that wait_for_job remains conservative;
+# any state that should be treated as non-terminal must be listed here.
 _STATUS_MAP = {
+    # Non-terminal — pending/queued
     "PENDING": JobStatus.PENDING,
+    "CONFIGURING": JobStatus.PENDING,
+    "REQUEUED": JobStatus.PENDING,
+    # Non-terminal — running/active
     "RUNNING": JobStatus.RUNNING,
+    "RESIZING": JobStatus.RUNNING,
+    "SUSPENDED": JobStatus.RUNNING,
+    "COMPLETING": JobStatus.RUNNING,
+    # Terminal — success
     "COMPLETED": JobStatus.COMPLETED,
+    # Terminal — failure
     "FAILED": JobStatus.FAILED,
+    "BOOT_FAIL": JobStatus.FAILED,
+    "NODE_FAIL": JobStatus.FAILED,
+    "OUT_OF_MEMORY": JobStatus.FAILED,
+    # Terminal — cancelled
     "CANCELLED": JobStatus.CANCELLED,
+    "PREEMPTED": JobStatus.CANCELLED,
+    "REVOKED": JobStatus.CANCELLED,
+    # Terminal — timeout
     "TIMEOUT": JobStatus.TIMEOUT,
+    "DEADLINE": JobStatus.TIMEOUT,
 }
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,159 @@
 """Scheduler unit tests."""
 
-from hpc.scheduler import PJM
+from hpc.scheduler import PJM, Slurm, JobStatus
+
+
+class TestSlurmStatusCmd:
+    def test_status_cmd_includes_X_flag(self):
+        scheduler = Slurm()
+
+        cmd = scheduler.status_cmd("12345678")
+
+        # -X suppresses jobsteps so each row is one allocation; without it
+        # array-task aggregation would conflate steps with tasks.
+        assert "-X" in cmd
+        assert "sacct" in cmd
+        assert "12345678" in cmd
+        assert "--noheader" in cmd
+
+
+class TestSlurmParseStatus:
+    # Single-line cases — preserves backward compat with single-job mocks
+    # and exercises every entry in the status map.
+
+    def test_single_completed(self):
+        assert Slurm().parse_status("COMPLETED\n") == JobStatus.COMPLETED
+
+    def test_single_pending(self):
+        assert Slurm().parse_status("PENDING\n") == JobStatus.PENDING
+
+    def test_single_running(self):
+        assert Slurm().parse_status("RUNNING\n") == JobStatus.RUNNING
+
+    def test_single_failed(self):
+        assert Slurm().parse_status("FAILED\n") == JobStatus.FAILED
+
+    def test_single_cancelled(self):
+        assert Slurm().parse_status("CANCELLED\n") == JobStatus.CANCELLED
+
+    def test_single_timeout(self):
+        assert Slurm().parse_status("TIMEOUT\n") == JobStatus.TIMEOUT
+
+    def test_single_requeued_is_non_terminal(self):
+        # REQUEUED is a transient state where Slurm has put the job back in
+        # the queue; wait_for_job must keep polling, not exit.
+        assert Slurm().parse_status("REQUEUED\n") == JobStatus.PENDING
+
+    def test_single_suspended_is_non_terminal(self):
+        assert Slurm().parse_status("SUSPENDED\n") == JobStatus.RUNNING
+
+    def test_single_completing_is_non_terminal(self):
+        # COMPLETING means the job is finishing cleanup but processes may
+        # still be active on some nodes; treating it as terminal would
+        # exit wait_for_job before output files are flushed.
+        assert Slurm().parse_status("COMPLETING\n") == JobStatus.RUNNING
+
+    def test_single_configuring_is_non_terminal(self):
+        assert Slurm().parse_status("CONFIGURING\n") == JobStatus.PENDING
+
+    def test_single_resizing_is_non_terminal(self):
+        assert Slurm().parse_status("RESIZING\n") == JobStatus.RUNNING
+
+    def test_single_boot_fail(self):
+        assert Slurm().parse_status("BOOT_FAIL\n") == JobStatus.FAILED
+
+    def test_single_node_fail(self):
+        assert Slurm().parse_status("NODE_FAIL\n") == JobStatus.FAILED
+
+    def test_single_out_of_memory(self):
+        assert Slurm().parse_status("OUT_OF_MEMORY\n") == JobStatus.FAILED
+
+    def test_single_deadline(self):
+        assert Slurm().parse_status("DEADLINE\n") == JobStatus.TIMEOUT
+
+    def test_single_preempted(self):
+        assert Slurm().parse_status("PREEMPTED\n") == JobStatus.CANCELLED
+
+    def test_single_revoked(self):
+        assert Slurm().parse_status("REVOKED\n") == JobStatus.CANCELLED
+
+    # Trailing-+ handling — sacct appends a bare "+" to some states
+    # (e.g. "COMPLETED+", "CANCELLED+") to flag extra context;
+    # rstrip("+") must apply to every aggregated row, not just the first.
+
+    def test_completed_with_plus_suffix(self):
+        assert Slurm().parse_status("COMPLETED+\n") == JobStatus.COMPLETED
+
+    def test_aggregation_strips_plus_on_every_row(self):
+        output = "COMPLETED+\nCOMPLETED+\nCOMPLETED+\n"
+        assert Slurm().parse_status(output) == JobStatus.COMPLETED
+
+    # Empty / unknown — empty output preserves the pre-existing FAILED
+    # behavior; unknown states fall back to FAILED so we stay
+    # conservative with respect to wait termination.
+
+    def test_empty_output(self):
+        assert Slurm().parse_status("") == JobStatus.FAILED
+
+    def test_whitespace_only_output(self):
+        assert Slurm().parse_status("   \n  \n") == JobStatus.FAILED
+
+    def test_unknown_status_falls_back_to_failed(self):
+        assert Slurm().parse_status("BOGUS_STATE\n") == JobStatus.FAILED
+
+    # Aggregation — array-job scenarios. The invariant under test is
+    # aggregate(S) ∈ terminal_states ⟺ ∀ s ∈ S, s ∈ terminal_states.
+
+    def test_aggregate_all_completed(self):
+        output = "COMPLETED\nCOMPLETED\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.COMPLETED
+
+    def test_aggregate_one_pending_others_completed(self):
+        # Regression guard: the previous parse_status only inspected lines[0]
+        # and returned COMPLETED while later tasks were still pending.
+        output = "COMPLETED\nCOMPLETED\nPENDING\n"
+        assert Slurm().parse_status(output) == JobStatus.PENDING
+
+    def test_aggregate_pending_first_others_running(self):
+        # Even when PENDING appears first, RUNNING wins (RUNNING > PENDING).
+        output = "PENDING\nRUNNING\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.RUNNING
+
+    def test_aggregate_one_running_dominates_pending(self):
+        output = "PENDING\nPENDING\nRUNNING\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.RUNNING
+
+    def test_aggregate_requeued_keeps_array_non_terminal(self):
+        # A single REQUEUED task in an otherwise-completed array must not
+        # mark the array terminal; wait_for_job must keep polling.
+        output = "COMPLETED\nCOMPLETED\nREQUEUED\n"
+        assert Slurm().parse_status(output) == JobStatus.PENDING
+
+    def test_aggregate_terminal_failure_dominates_completed(self):
+        # All tasks terminal but at least one FAILED → array is FAILED.
+        output = "COMPLETED\nCOMPLETED\nFAILED\n"
+        assert Slurm().parse_status(output) == JobStatus.FAILED
+
+    def test_aggregate_failed_dominates_cancelled(self):
+        output = "COMPLETED\nCANCELLED\nFAILED\n"
+        assert Slurm().parse_status(output) == JobStatus.FAILED
+
+    def test_aggregate_cancelled_dominates_timeout(self):
+        # FAILED > CANCELLED > TIMEOUT — when no FAILED present,
+        # CANCELLED wins over TIMEOUT.
+        output = "COMPLETED\nTIMEOUT\nCANCELLED\n"
+        assert Slurm().parse_status(output) == JobStatus.CANCELLED
+
+    def test_aggregate_running_beats_failed_terminal(self):
+        # Even with a failed task, an in-flight task must keep the
+        # aggregate non-terminal so wait_for_job does not exit while
+        # other tasks are still running.
+        output = "FAILED\nRUNNING\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.RUNNING
+
+    def test_aggregate_pending_beats_failed_terminal(self):
+        output = "FAILED\nPENDING\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.PENDING
 
 
 class TestPJMParseJobID:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -173,6 +173,18 @@ class TestSlurmParseStatus:
         # even though OUT_OF_MEMORY is terminal failure.
         assert Slurm().parse_status(output) == JobStatus.PENDING
 
+    def test_cancelled_by_user_extended_form(self):
+        # With the widened State%30 column, sacct emits the full
+        # "CANCELLED by <uid>" form instead of truncating to "CANCELLED+".
+        # Taking the first whitespace-separated token reduces it to
+        # "CANCELLED" so the status map matches.
+        output = "CANCELLED by 12345\n"
+        assert Slurm().parse_status(output) == JobStatus.CANCELLED
+
+    def test_aggregate_with_cancelled_by_user(self):
+        output = "COMPLETED\nCOMPLETED\nCANCELLED by 12345\n"
+        assert Slurm().parse_status(output) == JobStatus.CANCELLED
+
 
 class TestPJMParseJobID:
     def test_parse_job_id_prefers_job_token(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -16,6 +16,15 @@ class TestSlurmStatusCmd:
         assert "12345678" in cmd
         assert "--noheader" in cmd
 
+    def test_status_cmd_widens_state_column(self):
+        # sacct's default column width is 10 chars, which truncates long
+        # state names like CONFIGURING / OUT_OF_MEMORY into "CONFIGUR+" and
+        # silently maps them to FAILED via the unknown-state fallback.
+        # Pin the explicit width so the format never narrows back.
+        cmd = Slurm().status_cmd("12345678")
+
+        assert "--format=State%30" in cmd
+
 
 class TestSlurmParseStatus:
     # Single-line cases — preserves backward compat with single-job mocks
@@ -153,6 +162,15 @@ class TestSlurmParseStatus:
 
     def test_aggregate_pending_beats_failed_terminal(self):
         output = "FAILED\nPENDING\nCOMPLETED\n"
+        assert Slurm().parse_status(output) == JobStatus.PENDING
+
+    def test_padded_output_from_widened_state_column(self):
+        # sacct with --format=State%30 right-pads each row with spaces;
+        # the per-row strip() must reduce the padded value to its bare
+        # state name before the status-map lookup.
+        output = "CONFIGURING                   \nOUT_OF_MEMORY                 \n"
+        # CONFIGURING is non-terminal (PENDING); aggregate stays non-terminal
+        # even though OUT_OF_MEMORY is terminal failure.
         assert Slurm().parse_status(output) == JobStatus.PENDING
 
 


### PR DESCRIPTION
## Summary

`hpc wait <array_job_id>` returned long before a Slurm array job actually finished. `Slurm.parse_status` only inspected the first `sacct` row, so an array with `COMPLETED, COMPLETED, ..., RUNNING, PENDING` was reported `COMPLETED` while ~150 tasks were still pending.

This PR aggregates `parse_status` across every `sacct` row with priority `RUNNING > PENDING > FAILED > CANCELLED > TIMEOUT > COMPLETED`, so the array is reported terminal only when every task is terminal. Side fixes that surfaced during review:

- Add `-X` to `sacct` so each row is one allocation (one row per array task), not jobsteps.
- Pin `--format=State%30` so long state names like `CONFIGURING` and `OUT_OF_MEMORY` are not truncated by sacct's 10-char default — truncation would survive `rstrip("+")` as a prefix that misses `_STATUS_MAP` and falls back to `FAILED`.
- Tokenize each row to its first whitespace-separated token, so widened-column extended forms such as `CANCELLED by 12345` reduce back to `CANCELLED`.
- Expand `_STATUS_MAP` from 6 to 18 known Slurm states (REQUEUED / SUSPENDED / COMPLETING / CONFIGURING / RESIZING as non-terminal; BOOT_FAIL / NODE_FAIL / OUT_OF_MEMORY → FAILED; PREEMPTED / REVOKED → CANCELLED; DEADLINE → TIMEOUT). Without this, a transient task in REQUEUED would aggregate to FAILED via the unknown-state fallback and exit the wait prematurely.

PJM's `parse_status` likely has the same fixed-index bug at `lines[1]`, but verifying it requires running against a real PJM cluster; that work is deferred to a follow-up issue.

Closes #7.

## Test plan

- [x] `uv run pytest` — 156 passed (was 119; +37 new tests covering aggregation precedence, every status-map entry, padded/widened output, `CANCELLED by <uid>`, empty/whitespace, unknown-state fallback)
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [ ] Manual verification on a real Slurm cluster with a mixed-state array job