### PR TITLE
fix(submit): honor #SBATCH/#PJM directives in user-supplied scripts

### DIFF
--- a/.claude/skills/hpc/SKILL.md
+++ b/.claude/skills/hpc/SKILL.md
@@ -41,7 +41,7 @@ If `hpc.toml` does not exist in the project, run `hpc init` to create it, then a
 - Start from the assumption that PWD is already `[cluster].workdir`. No `cd` needed for the common case.
 - If you genuinely need a different working directory, prefer an explicit absolute path or a `WORKDIR` env-var override; do **not** rely on `$SLURM_SUBMIT_DIR` (the scheduler does not always propagate it into the job's shell env).
 - The script's stdout/stderr land in the scheduler's job-output files, retrievable via `hpc job-output <id>`.
-- `#SBATCH` / `#PJM` directives at the top of the script (column-zero, before the first executable line) are honored: hpc hoists them into the rendered job-script prologue. On conflict with `[slurm.options]` / `[pjm.options]`, the script's value wins.
+- `#SBATCH` / `#PJM` directives at the top of the script (column-zero, before the first executable line) are honored: hpc hoists them into the rendered job-script prologue. On conflict with the corresponding config entry (`[slurm.options]` for Slurm, the `pjm.options` array for PJM), the script's value wins.
 
 ## Common pitfalls
 

--- a/.claude/skills/hpc/SKILL.md
+++ b/.claude/skills/hpc/SKILL.md
@@ -41,6 +41,7 @@ If `hpc.toml` does not exist in the project, run `hpc init` to create it, then a
 - Start from the assumption that PWD is already `[cluster].workdir`. No `cd` needed for the common case.
 - If you genuinely need a different working directory, prefer an explicit absolute path or a `WORKDIR` env-var override; do **not** rely on `$SLURM_SUBMIT_DIR` (the scheduler does not always propagate it into the job's shell env).
 - The script's stdout/stderr land in the scheduler's job-output files, retrievable via `hpc job-output <id>`.
+- `#SBATCH` / `#PJM` directives at the top of the script (column-zero, before the first executable line) are honored: hpc hoists them into the rendered job-script prologue. On conflict with `[slurm.options]` / `[pjm.options]`, the script's value wins.
 
 ## Common pitfalls
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ hpc submit --workdir /scratch/user/other "python train.py"  # override remote wo
 
 Only column-zero directive lines that appear before the first executable line in the user script are hoisted, matching the schedulers' own prologue-scan rule. Directives after an executable line, or inside heredocs, are left in the body as-is.
 
-When the same option is set both in `[slurm.options]` / `[pjm.options]` and via a `#SBATCH` / `#PJM` line in the script, the script's value wins (the scheduler's last-occurrence-wins semantics for duplicate directives). The `submit_options` list is passed as command-line flags to `sbatch` / `pjsub` and, per scheduler specifications, overrides script directives unconditionally.
+When the same option is set both via config (`[slurm.options]` for Slurm, the `pjm.options` array for PJM) and via a `#SBATCH` / `#PJM` line in the script, the script's value wins (the scheduler's last-occurrence-wins semantics for duplicate directives). The `submit_options` list is passed as command-line flags to `sbatch` / `pjsub` and, per scheduler specifications, overrides script directives unconditionally.
 
 ### `hpc status`
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ hpc submit -s run.sh --wait
 hpc submit --workdir /scratch/user/other "python train.py"  # override remote workdir
 ```
 
+`#SBATCH` (Slurm) and `#PJM` (PJM) directives written at the top of a script passed via `--script` are honored: hpc hoists them into the prologue of the rendered job script, so they are scanned by `sbatch` / `pjsub` instead of being silently treated as comments.
+
+Only column-zero directive lines that appear before the first executable line in the user script are hoisted, matching the schedulers' own prologue-scan rule. Directives after an executable line, or inside heredocs, are left in the body as-is.
+
+When the same option is set both in `[slurm.options]` / `[pjm.options]` and via a `#SBATCH` / `#PJM` line in the script, the script's value wins (the scheduler's last-occurrence-wins semantics for duplicate directives). The `submit_options` list is passed as command-line flags to `sbatch` / `pjsub` and, per scheduler specifications, overrides script directives unconditionally.
+
 ### `hpc status`
 
 Checks the status of a submitted job.

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -47,14 +47,21 @@ def _extract_prologue_directives(content: str, prefix: str) -> tuple[list[str], 
     """Hoist scheduler directives from a user-supplied script's prologue.
 
     Mirrors the prologue-scan that sbatch and pjsub themselves perform:
-    starting from the top of `content`, accept only shebang, blank,
-    comment, and matching-prefix directive lines; stop at the first
-    non-comment, non-blank executable line and leave everything from
-    there onward untouched. Directive lines are matched at column zero
-    with ``^<prefix>\\b`` (matching the schedulers' own column-zero
-    rule) and removed from the body. A leading ``#!`` shebang line, if
-    present, is dropped because the rendered job-script template
-    injects its own.
+    starting from the top of `content`, accept only shebang, truly-blank
+    (``\\n`` / ``\\r\\n``), column-zero comment (``#...``), and column-
+    zero matching-prefix directive lines; stop at the first line that
+    is none of those (executable, indented comment, or whitespace-only)
+    and leave everything from there onward untouched. Treating indented
+    comments and whitespace-only lines as scan-terminating — rather
+    than as bash-style blanks/comments — is intentional: the schedulers
+    themselves are column-sensitive, so being any more permissive would
+    cause ``hpc submit -s script.sh`` to honor directives that
+    ``sbatch script.sh`` standalone would have ignored.
+
+    Directive lines are matched at column zero with ``^<prefix>\\b`` and
+    removed from the body. A leading ``#!`` shebang line, if present,
+    is dropped because the rendered job-script template injects its
+    own.
 
     Without this hoist, directives written inside user scripts land
     after the template's ``cd workdir`` and env-setup lines and are
@@ -79,17 +86,17 @@ def _extract_prologue_directives(content: str, prefix: str) -> tuple[list[str], 
 
     for line in lines[start:]:
         if in_prologue:
-            stripped = line.strip()
-            if not stripped:
+            if line in ("\n", "\r\n"):
                 body_parts.append(line)
             elif directive_re.match(line):
                 directives.append(line.rstrip("\r\n"))
-            elif stripped.startswith("#"):
-                # Non-directive comment (any indent): bash treats it as
-                # a comment and the scheduler's prologue scan skips it,
-                # so we keep it in the body and continue scanning.
+            elif line.startswith("#"):
+                # Column-zero non-directive comment: scheduler skips it
+                # and the prologue scan continues.
                 body_parts.append(line)
             else:
+                # Anything else — executable, indented comment, or
+                # whitespace-only — terminates the prologue scan.
                 in_prologue = False
                 body_parts.append(line)
         else:

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -1,5 +1,6 @@
 """Job management for HPC schedulers"""
 
+import re
 from pathlib import Path
 
 from jinja2 import Template
@@ -26,6 +27,9 @@ JOB_TEMPLATE = """#!/bin/bash
 {% for directive in directives %}
 {{ directive }}
 {% endfor %}
+{% for directive in user_directives %}
+{{ directive }}
+{% endfor %}
 {{ scheduler.directive_prefix().split()[0] }} --output={{ workdir }}/.hpc/runs/{{ run_id }}/job-%j.out
 {{ scheduler.directive_prefix().split()[0] }} --error={{ workdir }}/.hpc/runs/{{ run_id }}/job-%j.err
 
@@ -37,6 +41,61 @@ cd {{ job_workdir }}
 
 {{ cmd }}
 """
+
+
+def _extract_prologue_directives(content: str, prefix: str) -> tuple[list[str], str]:
+    """Hoist scheduler directives from a user-supplied script's prologue.
+
+    Mirrors the prologue-scan that sbatch and pjsub themselves perform:
+    starting from the top of `content`, accept only shebang, blank,
+    comment, and matching-prefix directive lines; stop at the first
+    non-comment, non-blank executable line and leave everything from
+    there onward untouched. Directive lines are matched at column zero
+    with ``^<prefix>\\b`` (matching the schedulers' own column-zero
+    rule) and removed from the body. A leading ``#!`` shebang line, if
+    present, is dropped because the rendered job-script template
+    injects its own.
+
+    Without this hoist, directives written inside user scripts land
+    after the template's ``cd workdir`` and env-setup lines and are
+    silently ignored by the scheduler.
+
+    Returns ``(directives_in_original_order, body_text)``. Directives
+    have no trailing newline; body_text concatenates the kept lines
+    and preserves original line endings.
+    """
+    if not content:
+        return [], content
+
+    lines = content.splitlines(keepends=True)
+    directives: list[str] = []
+    body_parts: list[str] = []
+
+    # Strip a leading shebang only; the template injects its own.
+    start = 1 if lines and lines[0].startswith("#!") else 0
+
+    directive_re = re.compile(rf"^{re.escape(prefix)}\b")
+    in_prologue = True
+
+    for line in lines[start:]:
+        if in_prologue:
+            stripped = line.strip()
+            if not stripped:
+                body_parts.append(line)
+            elif directive_re.match(line):
+                directives.append(line.rstrip("\r\n"))
+            elif stripped.startswith("#"):
+                # Non-directive comment (any indent): bash treats it as
+                # a comment and the scheduler's prologue scan skips it,
+                # so we keep it in the body and continue scanning.
+                body_parts.append(line)
+            else:
+                in_prologue = False
+                body_parts.append(line)
+        else:
+            body_parts.append(line)
+
+    return directives, "".join(body_parts)
 
 
 class JobManager:
@@ -93,14 +152,17 @@ class JobManager:
         )
         directives = self._build_directives(options, run.run_id)
         setup_commands = self.config.env.get_setup_commands()
+        prefix = self.scheduler.directive_prefix().split()[0]
+        user_directives, body = _extract_prologue_directives(run.cmd, prefix)
         return template.render(
             run_id=run.run_id,
             directives=directives,
+            user_directives=user_directives,
             scheduler=self.scheduler,
             workdir=workdir,
             job_workdir=job_workdir,
             setup_commands=setup_commands,
-            cmd=run.cmd,
+            cmd=body,
         )
 
     def submit_run(self, run: RunConfig, cwd_relative: Path = Path(".")) -> str:
@@ -133,14 +195,17 @@ class JobManager:
         directives = self._build_directives(options, "job")
 
         setup_commands = self.config.env.get_setup_commands()
+        prefix = self.scheduler.directive_prefix().split()[0]
+        user_directives, body = _extract_prologue_directives(cmd, prefix)
         script = template.render(
             run_id="job",
             directives=directives,
+            user_directives=user_directives,
             scheduler=self.scheduler,
             workdir=workdir,
             job_workdir=workdir,
             setup_commands=setup_commands,
-            cmd=cmd,
+            cmd=body,
         )
         submit_cmd = self.scheduler.submit_cmd()
         submit_options = self._get_submit_options()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from hpc.job import JobManager, JobStatus
+from hpc.job import JobManager, JobStatus, _extract_prologue_directives
 from hpc.scheduler import JobDetail
 from hpc.ssh import SSHManager, SSHError
 from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig, PjmConfig
@@ -320,3 +320,215 @@ class TestJobManagerTailJobOutput:
 
         rc = manager.tail_job_output("run_id", "12345678")
         assert rc == 130
+
+
+class TestExtractPrologueDirectives:
+    """Helper that hoists scheduler directives from user-supplied script content."""
+
+    def test_empty_content(self):
+        directives, body = _extract_prologue_directives("", "#SBATCH")
+        assert directives == []
+        assert body == ""
+
+    def test_shebang_only(self):
+        directives, body = _extract_prologue_directives("#!/bin/bash\n", "#SBATCH")
+        assert directives == []
+        assert body == ""
+
+    def test_shebang_dropped_with_body(self):
+        content = "#!/bin/bash\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        assert body == "echo hi\n"
+
+    def test_no_shebang_no_directives_unchanged(self):
+        directives, body = _extract_prologue_directives("echo hi\n", "#SBATCH")
+        assert directives == []
+        assert body == "echo hi\n"
+
+    def test_extracts_slurm_directive_after_shebang(self):
+        content = "#!/bin/bash\n#SBATCH --array=1-10%5\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == ["#SBATCH --array=1-10%5"]
+        assert body == "echo hi\n"
+
+    def test_extracts_pjm_directive(self):
+        content = '#!/bin/bash\n#PJM -L "node=4"\n#PJM -j\necho pjm\n'
+        directives, body = _extract_prologue_directives(content, "#PJM")
+        assert directives == ['#PJM -L "node=4"', "#PJM -j"]
+        assert body == "echo pjm\n"
+
+    def test_pjm_prefix_does_not_match_sbatch_lines(self):
+        content = "#PJM -L node=4\n#SBATCH --array=1-5\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#PJM")
+        assert directives == ["#PJM -L node=4"]
+        # `#SBATCH ...` is a non-directive comment for the PJM matcher and
+        # stays in the body. Prologue scan continues past it.
+        assert body == "#SBATCH --array=1-5\necho hi\n"
+
+    def test_directive_after_first_executable_not_hoisted(self):
+        # Mirrors scheduler behavior: once an executable line is seen,
+        # subsequent #SBATCH lines are ignored.
+        content = "#!/bin/bash\necho before\n#SBATCH --array=1-5\necho after\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        assert body == "echo before\n#SBATCH --array=1-5\necho after\n"
+
+    def test_heredoc_directive_lookalike_not_hoisted(self):
+        content = "#!/bin/bash\ncat <<EOF\n#SBATCH --bogus=1\nEOF\necho done\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        # `cat <<EOF` is the first executable line; everything after it is
+        # preserved verbatim, including the directive-look-alike heredoc body.
+        assert body == "cat <<EOF\n#SBATCH --bogus=1\nEOF\necho done\n"
+
+    def test_blank_lines_between_directives_preserved(self):
+        content = (
+            "#!/bin/bash\n"
+            "\n"
+            "#SBATCH --partition=gpu\n"
+            "\n"
+            "#SBATCH --time=01:00:00\n"
+            "echo hi\n"
+        )
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == ["#SBATCH --partition=gpu", "#SBATCH --time=01:00:00"]
+        # Blank lines between hoisted directives are kept in body — they are
+        # comments to the scheduler and do not terminate the prologue scan.
+        assert body == "\n\necho hi\n"
+
+    def test_non_directive_comment_preserved_in_prologue(self):
+        # A `# regular comment` line does not terminate the prologue scan,
+        # but it is also not a directive — it stays in the body.
+        content = "#!/bin/bash\n# user explanation\n#SBATCH --partition=gpu\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == ["#SBATCH --partition=gpu"]
+        assert body == "# user explanation\necho hi\n"
+
+    def test_indented_directive_not_hoisted(self):
+        # Schedulers require column-zero `#SBATCH`; indented lines are
+        # bash comments, not directives.
+        content = "#!/bin/bash\n  #SBATCH --partition=gpu\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        assert body == "  #SBATCH --partition=gpu\necho hi\n"
+
+    def test_no_trailing_newline_preserved(self):
+        directives, body = _extract_prologue_directives("echo hi", "#SBATCH")
+        assert directives == []
+        assert body == "echo hi"
+
+
+class TestJobManagerHoistsUserDirectives:
+    def test_render_hoists_sbatch_directive_from_script_body(
+        self, mock_ssh_manager, sample_config
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        from hpc.run import RunConfig
+
+        cmd = "#!/bin/bash\n#SBATCH --array=1-10%5\necho hi\n"
+        run = RunConfig(run_id="test_run", cmd=cmd, status="pending")
+        script = manager._render_job_script(run)
+
+        # User directive lands in the prologue, before `cd`.
+        array_idx = script.index("#SBATCH --array=1-10%5")
+        cd_idx = script.index("cd /scratch/user/proj")
+        assert array_idx < cd_idx
+        # And before the template's hardcoded --output= bookkeeping line, so
+        # hpc's run-tracking output path always wins over any user override.
+        output_idx = script.index("--output=/scratch/user/proj/.hpc/runs/test_run")
+        assert array_idx < output_idx
+        # User shebang is stripped (template emits its own).
+        assert script.count("#!/bin/bash") == 1
+        # Body retains the executable line.
+        assert "echo hi" in script
+
+    def test_render_hoists_multiple_pjm_directives(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=12"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        from hpc.run import RunConfig
+
+        cmd = '#!/bin/bash\n#PJM -L "rscgrp=small"\n#PJM -j\n#PJM -N myjob\necho pjm\n'
+        run = RunConfig(run_id="test_run", cmd=cmd, status="pending")
+        script = manager._render_job_script(run)
+
+        cd_idx = script.index("cd /scratch/user/proj")
+        for directive in ('#PJM -L "rscgrp=small"', "#PJM -j", "#PJM -N myjob"):
+            assert directive in script
+            assert script.index(directive) < cd_idx
+        # Original order preserved.
+        assert (
+            script.index('#PJM -L "rscgrp=small"')
+            < script.index("#PJM -j")
+            < script.index("#PJM -N myjob")
+        )
+
+    def test_user_directive_emitted_after_config_directive_slurm(
+        self, mock_ssh_manager, sample_config
+    ):
+        """User directive wins on conflict via scheduler last-occurrence-wins."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        from hpc.run import RunConfig
+
+        cmd = "#!/bin/bash\n#SBATCH --partition=cpu\necho hi\n"
+        run = RunConfig(run_id="test_run", cmd=cmd, status="pending")
+        script = manager._render_job_script(run)
+
+        config_partition = script.index("#SBATCH --partition=gpu")
+        user_partition = script.index("#SBATCH --partition=cpu")
+        assert config_partition < user_partition
+
+    def test_user_directive_emitted_after_config_directive_pjm(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=12"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        from hpc.run import RunConfig
+
+        cmd = '#!/bin/bash\n#PJM -L "node=4"\necho pjm\n'
+        run = RunConfig(run_id="test_run", cmd=cmd, status="pending")
+        script = manager._render_job_script(run)
+
+        config_node = script.index("#PJM -L node=12")
+        user_node = script.index('#PJM -L "node=4"')
+        assert config_node < user_node
+
+    def test_render_no_user_directives_unchanged(self, mock_ssh_manager, sample_config):
+        """Plain command without directives: rendered output matches the
+        pre-hoist behavior — user_directives block emits nothing extra."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="python train.py", status="pending")
+        script = manager._render_job_script(run)
+        # Sanity: the command body is at the bottom, config directives at top.
+        assert "python train.py" in script
+        assert script.index("#SBATCH --partition=gpu") < script.index("python train.py")
+
+    def test_legacy_submit_job_hoists_user_directives(
+        self, mock_ssh_manager, sample_config
+    ):
+        """Legacy `submit_job(cmd)` path also hoists user directives so the
+        two submission paths render consistent prologues."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
+
+        cmd = "#!/bin/bash\n#SBATCH --array=1-5\necho hi\n"
+        manager.submit_job(cmd)
+
+        # The rendered script is piped to sbatch via input_text.
+        call_args = mock_ssh_manager.run_command.call_args
+        script = call_args.kwargs["input_text"]
+        cd_idx = script.index("cd /scratch/user/proj")
+        assert script.index("#SBATCH --array=1-5") < cd_idx
+        assert script.count("#!/bin/bash") == 1

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -406,12 +406,39 @@ class TestExtractPrologueDirectives:
         assert body == "# user explanation\necho hi\n"
 
     def test_indented_directive_not_hoisted(self):
-        # Schedulers require column-zero `#SBATCH`; indented lines are
-        # bash comments, not directives.
+        # Schedulers require column-zero `#SBATCH`; an indented line is
+        # not a directive, and being non-blank-non-column-zero-comment
+        # it also terminates the prologue scan.
         content = "#!/bin/bash\n  #SBATCH --partition=gpu\necho hi\n"
         directives, body = _extract_prologue_directives(content, "#SBATCH")
         assert directives == []
         assert body == "  #SBATCH --partition=gpu\necho hi\n"
+
+    def test_indented_comment_terminates_prologue(self):
+        # An indented `# comment` is bash-style comment but not a
+        # column-zero comment; the schedulers stop scanning at this
+        # line, so a directive following it is not hoisted (matching
+        # what `sbatch script.sh` standalone would do).
+        content = "#!/bin/bash\n  # indented comment\n#SBATCH --array=1-5\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        assert body == "  # indented comment\n#SBATCH --array=1-5\necho hi\n"
+
+    def test_whitespace_only_line_terminates_prologue(self):
+        # A line containing only whitespace (not a true `\n`-only blank)
+        # is treated as scan-terminating, matching the schedulers'
+        # column-sensitive prologue rule.
+        content = "#!/bin/bash\n   \n#SBATCH --array=1-5\necho hi\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == []
+        assert body == "   \n#SBATCH --array=1-5\necho hi\n"
+
+    def test_crlf_blank_line_kept_in_prologue(self):
+        # Truly-blank lines (`\n` or `\r\n`) do not terminate the scan.
+        content = "#!/bin/bash\r\n\r\n#SBATCH --array=1-5\r\necho hi\r\n"
+        directives, body = _extract_prologue_directives(content, "#SBATCH")
+        assert directives == ["#SBATCH --array=1-5"]
+        assert body == "\r\necho hi\r\n"
 
     def test_no_trailing_newline_preserved(self):
         directives, body = _extract_prologue_directives("echo hi", "#SBATCH")


### PR DESCRIPTION
Closes #6.

## Summary

`#SBATCH` (Slurm) / `#PJM` (PJM) directives written in scripts passed via `hpc submit -s script.sh` were silently ignored. The job-script template placed user content below `cd workdir` and env-setup lines, past the point where `sbatch` / `pjsub` stop scanning prologue directives — so user directives ended up as ordinary comments.

## Root cause

`src/hpc/job.py`'s `JOB_TEMPLATE` rendered the user-supplied script content (`{{ cmd }}`) at the bottom, after the executable `cd job_workdir` line. Slurm and PJM both stop scanning `#SBATCH` / `#PJM` directives at the first non-comment, non-blank, non-directive line of the script, so the user's directives were never seen.

## Fix

Hoist column-zero `^#SBATCH\b` / `^#PJM\b` lines out of the user script's prologue and emit them in the rendered job-script prologue. The extractor mirrors the schedulers' own prologue-scan rule:

- a leading `#!` shebang is dropped (the template emits its own)
- blank lines and non-directive comment lines are kept in the body but do not terminate the scan
- the matching directive lines are extracted and removed from the body
- the first executable line ends the scan; everything from there onward is preserved verbatim (so directives inside heredocs or after the user's first command are not falsely hoisted)

User-supplied directives are emitted **after** config-derived `[slurm.options]` / `[pjm.options]` so they win on conflict via the schedulers' last-occurrence-wins semantics. The template's hardcoded `--output=` / `--error=` lines stay last, so hpc's run-tracking output paths are not user-overrideable.

## Test plan

- [x] `_extract_prologue_directives` helper unit tests (13 cases): empty input, shebang only / shebang + body, no shebang, Slurm and PJM extraction, prefix isolation between schedulers, post-executable directive not hoisted, heredoc directive-look-alike not hoisted, blank lines between directives preserved, non-directive comments kept in body, indented directive not hoisted, missing trailing newline preserved
- [x] integration tests on `_render_job_script` (5 cases): Slurm hoist with bookkeeping ordering, PJM multi-directive hoist with order preservation, conflict ordering for both schedulers, no-directive no-op
- [x] legacy `submit_job` path also hoists user directives (consistency between the two submission code paths)
- [x] full suite: 138 passed (baseline 119 + 19 new)
- [x] `pyright src/hpc/`: 0 errors, 0 warnings; `ruff check`, `ruff format --check`: clean

## Out of scope

- The PJM `--output=` / `--error=` lines emitted by the template currently use Slurm syntax (PJM expects `-o` / `-e`). Pre-existing bug, separate issue.
- Replacing `cd job_workdir` with Slurm `--chdir` / PJM `-d` would be an architectural cleanup but does not by itself fix the prologue-scan-termination problem (env-setup lines remain). Future work.
- Empirical verification of "last-occurrence wins" on real Slurm + Fugaku PJM clusters is deferred to post-deploy. If a scheduler turns out to be first-wins, the emit order needs to be flipped for that scheduler.
