### PR TITLE
feat(status): show sacct accounting fields for completed Slurm jobs

### DIFF
--- a/src/hpc/cli.py
+++ b/src/hpc/cli.py
@@ -285,6 +285,31 @@ def submit(
             raise typer.Exit(1)
 
 
+# Slurm State values that mean the job has finished and the accounting
+# fields (ExitCode / Elapsed / MaxRSS / ReqMem) are meaningful to display.
+_TERMINAL_SACCT_STATES = frozenset(
+    {
+        "COMPLETED",
+        "FAILED",
+        "CANCELLED",
+        "TIMEOUT",
+        "OUT_OF_MEMORY",
+        "BOOT_FAIL",
+        "NODE_FAIL",
+        "PREEMPTED",
+        "DEADLINE",
+        "REVOKED",
+        "SPECIAL_EXIT",
+    }
+)
+
+
+def _normalize_sacct_state(state: str) -> str:
+    """Strip Slurm State decorations like ``CANCELLED+`` / ``CANCELLED by 12345``."""
+    head = state.split()[0] if state else ""
+    return head.rstrip("+")
+
+
 @app.command()
 def status(id: str = typer.Argument(None), config: ConfigOption = None):
     """Check job status (accepts run_id or job_id)"""
@@ -316,8 +341,20 @@ def status(id: str = typer.Argument(None), config: ConfigOption = None):
     ssh = SSHManager(host=hpc_config.cluster.host)
     job_manager = JobManager(ssh_manager=ssh, config=hpc_config)
 
-    job_status = job_manager.get_job_status(job_id)
-    print(f"Job {job_id}: {job_status.value}")
+    detail = job_manager.get_job_detail(job_id)
+    if detail is None or not detail.state:
+        # Scheduler does not support detail (PJM), or sacct has not yet
+        # recorded this job. Fall back to the existing single-line display.
+        job_status = job_manager.get_job_status(job_id)
+        print(f"Job {job_id}: {job_status.value}")
+        return
+
+    print(f"Job {job_id}: {detail.state}")
+    if _normalize_sacct_state(detail.state) in _TERMINAL_SACCT_STATES:
+        print(f"  ExitCode: {detail.exit_code or '-'}")
+        print(f"  Elapsed:  {detail.elapsed or '-'}")
+        print(f"  MaxRSS:   {detail.max_rss or '-'}")
+        print(f"  ReqMem:   {detail.req_mem or '-'}")
 
 
 @app.command(name="list")

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 from .config import HpcConfig
 from .ssh import SSHManager
 from .run import RunConfig
-from .scheduler import JobStatus, get_scheduler
+from .scheduler import JobDetail, JobStatus, get_scheduler
 
 
 def _resolve_home_path(ssh_manager, path: str) -> str:
@@ -154,6 +154,14 @@ class JobManager:
         cmd = self.scheduler.status_cmd(job_id)
         result = self.ssh_manager.run_command(cmd[0], cmd[1:])
         return self.scheduler.parse_status(result.stdout)
+
+    def get_job_detail(self, job_id: str) -> JobDetail | None:
+        """Get detailed accounting info, or None if the scheduler does not support it."""
+        cmd = self.scheduler.detail_cmd(job_id)
+        if cmd is None:
+            return None
+        result = self.ssh_manager.run_command(cmd[0], cmd[1:])
+        return self.scheduler.parse_detail(result.stdout)
 
     def get_job_output(self, run_id: str, job_id: str, error: bool = False) -> str:
         """Get job output file contents"""

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -31,6 +31,28 @@ class JobDetail:
     req_mem: str
 
 
+_MAX_RSS_UNITS = {"K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+
+
+def _max_rss_to_bytes(value: str) -> int:
+    """Parse a Slurm MaxRSS field (e.g. ``1024K``, ``2.5G``, ``0``) to bytes.
+
+    Unparseable inputs sort as 0 so they lose any max-comparison.
+    """
+    if not value:
+        return 0
+    suffix = value[-1].upper()
+    if suffix in _MAX_RSS_UNITS:
+        try:
+            return int(float(value[:-1]) * _MAX_RSS_UNITS[suffix])
+        except ValueError:
+            return 0
+    try:
+        return int(float(value))
+    except ValueError:
+        return 0
+
+
 class Scheduler(ABC):
     @abstractmethod
     def directive_prefix(self) -> str: ...
@@ -148,13 +170,13 @@ class Slurm(Scheduler):
             return None
 
         # MaxRSS is per-step; the parent row typically reports an empty
-        # MaxRSS, while `.batch` carries the script's peak RSS. Prefer the
-        # `.batch` row's value, otherwise take the first non-empty across rows.
-        batch = next((r for r in rows if r[0].endswith(".batch")), None)
-        if batch is not None and batch[4]:
-            max_rss = batch[4]
-        else:
-            max_rss = next((r[4] for r in rows if r[4]), "")
+        # MaxRSS. For plain-cmd jobs the script's peak RSS lives on `.batch`,
+        # but jobs that dispatch the workload via `srun` get the real RSS
+        # on numbered step rows (`.0`, `.1`, ...) while `.batch` only
+        # reflects the launcher. Pick the maximum across all non-empty
+        # step rows so both shapes report correctly.
+        non_empty = [r[4] for r in rows if r[4]]
+        max_rss = max(non_empty, key=_max_rss_to_bytes, default="")
 
         state = parent[1]
         if not state:

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -2,6 +2,7 @@
 
 import re
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 
 
@@ -12,6 +13,22 @@ class JobStatus(Enum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
     TIMEOUT = "TIMEOUT"
+
+
+@dataclass
+class JobDetail:
+    """Raw scheduler-side job accounting fields.
+
+    Strings are stored verbatim from the scheduler so the user sees
+    the exact value (e.g. ``OUT_OF_MEMORY``, ``CANCELLED+``) without
+    any enum/unit normalization.
+    """
+
+    state: str
+    exit_code: str
+    elapsed: str
+    max_rss: str
+    req_mem: str
 
 
 class Scheduler(ABC):
@@ -29,6 +46,14 @@ class Scheduler(ABC):
 
     @abstractmethod
     def parse_status(self, output: str) -> JobStatus: ...
+
+    def detail_cmd(self, job_id: str) -> list[str] | None:
+        """Command that fetches detailed accounting info, or None if unsupported."""
+        return None
+
+    def parse_detail(self, output: str) -> JobDetail | None:
+        """Parse detail-command output, or None if unsupported / unparseable."""
+        return None
 
 
 class Slurm(Scheduler):
@@ -85,6 +110,63 @@ class Slurm(Scheduler):
             if status in statuses:
                 return status
         return JobStatus.COMPLETED
+
+    def detail_cmd(self, job_id: str) -> list[str] | None:
+        return [
+            "sacct",
+            "-j",
+            job_id,
+            "--format=JobID,State,ExitCode,Elapsed,MaxRSS,ReqMem",
+            "--noheader",
+            "-P",
+        ]
+
+    def parse_detail(self, output: str) -> JobDetail | None:
+        # sacct -P emits one row per accounting record (the parent step plus
+        # any sub-steps such as `.batch` / `.extern`). Columns appear in the
+        # order requested via --format. -P (parsable2) does not add a trailing
+        # '|', but we tolerate it so callers can pass -p output as well.
+        rows: list[list[str]] = []
+        for raw in output.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            fields = line.split("|")
+            if fields and fields[-1] == "":
+                fields.pop()
+            if len(fields) < 6:
+                continue
+            rows.append(fields[:6])
+
+        if not rows:
+            return None
+
+        # Parent step rows have a JobID without a '.' separator; sub-steps
+        # (`.batch`, `.extern`, `.0`, ...) always contain a dot.
+        parent = next((r for r in rows if "." not in r[0]), None)
+        if parent is None:
+            return None
+
+        # MaxRSS is per-step; the parent row typically reports an empty
+        # MaxRSS, while `.batch` carries the script's peak RSS. Prefer the
+        # `.batch` row's value, otherwise take the first non-empty across rows.
+        batch = next((r for r in rows if r[0].endswith(".batch")), None)
+        if batch is not None and batch[4]:
+            max_rss = batch[4]
+        else:
+            max_rss = next((r[4] for r in rows if r[4]), "")
+
+        state = parent[1]
+        if not state:
+            return None
+
+        return JobDetail(
+            state=state,
+            exit_code=parent[2],
+            elapsed=parent[3],
+            max_rss=max_rss,
+            req_mem=parent[5],
+        )
 
 
 class PJM(Scheduler):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,98 @@ def test_status_command_exists(cli_runner):
     assert result.exit_code == 0
 
 
+def test_status_prints_sacct_fields_for_terminal_job(cli_runner, temp_dir, monkeypatch):
+    """Terminal Slurm jobs show ExitCode/Elapsed/MaxRSS/ReqMem in addition to state."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = JobDetail(
+            state="OUT_OF_MEMORY",
+            exit_code="0:125",
+            elapsed="00:01:23",
+            max_rss="1024K",
+            req_mem="16Gn",
+        )
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert "Job 12345678: OUT_OF_MEMORY" in result.stdout
+    assert "ExitCode: 0:125" in result.stdout
+    assert "Elapsed:  00:01:23" in result.stdout
+    assert "MaxRSS:   1024K" in result.stdout
+    assert "ReqMem:   16Gn" in result.stdout
+
+
+def test_status_omits_sacct_fields_for_running_job(cli_runner, temp_dir, monkeypatch):
+    """Running jobs print only the state line; runtime fields are not yet meaningful."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = JobDetail(
+            state="RUNNING",
+            exit_code="0:0",
+            elapsed="00:00:30",
+            max_rss="",
+            req_mem="16Gn",
+        )
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert "Job 12345678: RUNNING" in result.stdout
+    assert "ExitCode" not in result.stdout
+    assert "Elapsed" not in result.stdout
+
+
+def test_status_falls_back_when_detail_unavailable(cli_runner, temp_dir, monkeypatch):
+    """PJM (and not-yet-recorded jobs) fall back to the single-line display."""
+    from hpc.job import JobStatus
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = None
+        instance.get_job_status.return_value = JobStatus.PENDING
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert "Job 12345678: PENDING" in result.stdout
+    assert "ExitCode" not in result.stdout
+
+
+def test_status_normalizes_decorated_cancelled_state(cli_runner, temp_dir, monkeypatch):
+    """``CANCELLED+`` and ``CANCELLED by 12345`` should still trigger detail rendering."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = JobDetail(
+            state="CANCELLED by 12345",
+            exit_code="0:15",
+            elapsed="00:00:42",
+            max_rss="",
+            req_mem="8Gn",
+        )
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert "Job 12345678: CANCELLED by 12345" in result.stdout
+    assert "ExitCode: 0:15" in result.stdout
+    assert "MaxRSS:   -" in result.stdout
+
+
 def test_config_option(cli_runner, temp_dir, monkeypatch):
     """Test --config option loads specified config file"""
     monkeypatch.chdir(temp_dir)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from hpc.job import JobManager, JobStatus
+from hpc.scheduler import JobDetail
 from hpc.ssh import SSHManager, SSHError
 from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig, PjmConfig
 
@@ -168,6 +169,44 @@ class TestJobManagerStatus:
         assert call_args.args[0] == "sacct"
         assert "12345678" in call_args.args[1]
         assert "--noheader" in call_args.args[1]
+
+
+class TestJobManagerDetail:
+    def test_get_job_detail_slurm_invokes_sacct_and_returns_detail(
+        self, mock_ssh_manager, sample_config
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout=(
+                "12345|COMPLETED|0:0|00:01:23||16Gn\n"
+                "12345.batch|COMPLETED|0:0|00:01:23|1024K|16Gn\n"
+            )
+        )
+
+        detail = manager.get_job_detail("12345")
+        assert detail == JobDetail(
+            state="COMPLETED",
+            exit_code="0:0",
+            elapsed="00:01:23",
+            max_rss="1024K",
+            req_mem="16Gn",
+        )
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "sacct"
+        assert "-P" in call_args.args[1]
+
+    def test_get_job_detail_pjm_returns_none_without_ssh_call(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+
+        assert manager.get_job_detail("12345") is None
+        mock_ssh_manager.run_command.assert_not_called()
 
 
 class TestJobManagerTemplate:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -237,7 +237,7 @@ class TestSlurmParseDetail:
             req_mem="16Gn",
         )
 
-    def test_parse_falls_back_to_first_nonempty_max_rss_when_no_batch_row(self):
+    def test_parse_picks_step_max_rss_when_no_batch_row(self):
         output = (
             "12345|COMPLETED|0:0|00:00:42||8Gn\n"
             "12345.0|COMPLETED|0:0|00:00:42|512K|8Gn\n"
@@ -245,6 +245,30 @@ class TestSlurmParseDetail:
         detail = Slurm().parse_detail(output)
         assert detail is not None
         assert detail.max_rss == "512K"
+
+    def test_parse_picks_largest_max_rss_across_srun_steps(self):
+        # MPI / GPU jobs that dispatch via `srun` put the real workload RSS
+        # on numbered step rows; `.batch` only reflects the launcher.
+        output = (
+            "12345|COMPLETED|0:0|01:23:45||64Gn\n"
+            "12345.batch|COMPLETED|0:0|01:23:45|10M|64Gn\n"
+            "12345.0|COMPLETED|0:0|01:23:45|2500M|64Gn\n"
+            "12345.extern|COMPLETED|0:0|01:23:45|0|64Gn\n"
+        )
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.max_rss == "2500M"
+
+    def test_parse_compares_max_rss_unit_aware(self):
+        # 1G must beat 999M even though "1G" sorts before "999M" lexically.
+        output = (
+            "12345|COMPLETED|0:0|00:10:00||16Gn\n"
+            "12345.batch|COMPLETED|0:0|00:10:00|999M|16Gn\n"
+            "12345.0|COMPLETED|0:0|00:10:00|1G|16Gn\n"
+        )
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.max_rss == "1G"
 
     def test_parse_tolerates_trailing_pipe_from_parsable_mode(self):
         output = "12345|COMPLETED|0:0|00:00:10||4Gn|\n12345.batch|COMPLETED|0:0|00:00:10|256K|4Gn|\n"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,6 @@
 """Scheduler unit tests."""
 
-from hpc.scheduler import PJM, Slurm, JobStatus
+from hpc.scheduler import PJM, JobDetail, JobStatus, Slurm
 
 
 class TestSlurmStatusCmd:
@@ -207,3 +207,88 @@ class TestPJMParseJobID:
         output = " unexpected output "
 
         assert scheduler.parse_job_id(output) == "unexpected output"
+
+
+class TestSlurmDetailCmd:
+    def test_detail_cmd_includes_required_format_and_parsable_flag(self):
+        cmd = Slurm().detail_cmd("12345")
+        assert cmd is not None
+        assert cmd[0] == "sacct"
+        assert "12345" in cmd
+        assert "--format=JobID,State,ExitCode,Elapsed,MaxRSS,ReqMem" in cmd
+        assert "--noheader" in cmd
+        assert "-P" in cmd
+
+
+class TestSlurmParseDetail:
+    def test_parse_typical_three_row_output(self):
+        # parent (MaxRSS empty) + .batch (carries MaxRSS) + .extern.
+        output = (
+            "12345|COMPLETED|0:0|00:01:23||16Gn\n"
+            "12345.batch|COMPLETED|0:0|00:01:23|1024K|16Gn\n"
+            "12345.extern|COMPLETED|0:0|00:01:23|0|16Gn\n"
+        )
+        detail = Slurm().parse_detail(output)
+        assert detail == JobDetail(
+            state="COMPLETED",
+            exit_code="0:0",
+            elapsed="00:01:23",
+            max_rss="1024K",
+            req_mem="16Gn",
+        )
+
+    def test_parse_falls_back_to_first_nonempty_max_rss_when_no_batch_row(self):
+        output = (
+            "12345|COMPLETED|0:0|00:00:42||8Gn\n"
+            "12345.0|COMPLETED|0:0|00:00:42|512K|8Gn\n"
+        )
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.max_rss == "512K"
+
+    def test_parse_tolerates_trailing_pipe_from_parsable_mode(self):
+        output = "12345|COMPLETED|0:0|00:00:10||4Gn|\n12345.batch|COMPLETED|0:0|00:00:10|256K|4Gn|\n"
+        detail = Slurm().parse_detail(output)
+        assert detail == JobDetail(
+            state="COMPLETED",
+            exit_code="0:0",
+            elapsed="00:00:10",
+            max_rss="256K",
+            req_mem="4Gn",
+        )
+
+    def test_parse_preserves_raw_oom_state(self):
+        output = "12345|OUT_OF_MEMORY|0:125|00:00:05||4Gn\n"
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.state == "OUT_OF_MEMORY"
+
+    def test_parse_preserves_decorated_cancelled_state(self):
+        output = "12345|CANCELLED+|0:0|00:00:03||4Gn\n"
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.state == "CANCELLED+"
+
+    def test_parse_empty_output_returns_none(self):
+        assert Slurm().parse_detail("") is None
+        assert Slurm().parse_detail("\n\n") is None
+
+    def test_parse_no_parent_row_returns_none(self):
+        # Only step rows present, no parent row -> cannot identify primary state.
+        output = "12345.batch|COMPLETED|0:0|00:00:05|256K|4Gn\n"
+        assert Slurm().parse_detail(output) is None
+
+    def test_parse_skips_short_rows(self):
+        # A malformed row (too few fields) is dropped, parent row still wins.
+        output = "broken\n12345|COMPLETED|0:0|00:00:05||4Gn\n"
+        detail = Slurm().parse_detail(output)
+        assert detail is not None
+        assert detail.state == "COMPLETED"
+
+
+class TestPJMDetailNotSupported:
+    def test_pjm_detail_cmd_returns_none(self):
+        assert PJM().detail_cmd("12345") is None
+
+    def test_pjm_parse_detail_returns_none(self):
+        assert PJM().parse_detail("anything") is None


### PR DESCRIPTION
## Summary

- `hpc status <id>` on a terminal Slurm job now prints `ExitCode`, `Elapsed`, `MaxRSS`, and `ReqMem` alongside the raw sacct State string, fetched via a single `sacct -j <id> --format=JobID,State,ExitCode,Elapsed,MaxRSS,ReqMem --noheader -P` call.
- The polling path (`status_cmd` / `parse_status` / `wait_for_job`) is left untouched. The new detail path is consumed only by `cli.status`.
- PJM (and any newly-submitted Slurm job that sacct has not yet recorded) falls back to the prior single-line display.
- `MaxRSS` is selected as the **unit-aware maximum** across all non-empty step rows, so jobs that dispatch via `srun` (where `.batch` only reflects the launcher) report the workload's real RSS rather than the launcher's small footprint.
- The raw sacct State string is preserved verbatim in the output (e.g. `OUT_OF_MEMORY`, `CANCELLED+`, `CANCELLED by 12345`); the `JobStatus` enum is not extended.

## Test plan

- [x] `uv run pytest` — 138 passed (baseline 119 + 19 new).
- [x] `uv run ruff check` — All checks passed.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run pyright src/hpc/` — 0 errors, 0 warnings.

Closes #5