### PR TITLE
fix(submit): emit scheduler-correct stdout/stderr directives

### DIFF
--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -225,6 +225,10 @@ class JobManager:
             setup_commands=setup_commands,
             cmd=body,
         )
+        # The rendered script's output directives point under ``run_dir``;
+        # ensure that directory exists before submission so the scheduler
+        # can open its stdout/stderr targets.
+        self.ssh_manager.run_command("mkdir", ["-p", run_dir])
         submit_cmd = self.scheduler.submit_cmd()
         submit_options = self._get_submit_options()
         result = self.ssh_manager.run_command(

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -30,8 +30,9 @@ JOB_TEMPLATE = """#!/bin/bash
 {% for directive in user_directives %}
 {{ directive }}
 {% endfor %}
-{{ scheduler.directive_prefix().split()[0] }} --output={{ workdir }}/.hpc/runs/{{ run_id }}/job-%j.out
-{{ scheduler.directive_prefix().split()[0] }} --error={{ workdir }}/.hpc/runs/{{ run_id }}/job-%j.err
+{% for directive in output_directives %}
+{{ directive }}
+{% endfor %}
 
 cd {{ job_workdir }}
 
@@ -152,6 +153,7 @@ class JobManager:
         template = Template(JOB_TEMPLATE)
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
         job_workdir = str(Path(workdir) / cwd_relative)
+        run_dir = f"{workdir}/.hpc/runs/{run.run_id}"
         options = (
             self.config.pjm.options
             if self.config.cluster.scheduler == "pjm"
@@ -165,6 +167,7 @@ class JobManager:
             run_id=run.run_id,
             directives=directives,
             user_directives=user_directives,
+            output_directives=self.scheduler.output_directives(run_dir),
             scheduler=self.scheduler,
             workdir=workdir,
             job_workdir=job_workdir,
@@ -191,9 +194,16 @@ class JobManager:
         return self.scheduler.parse_job_id(result.stdout)
 
     def submit_job(self, cmd: str) -> str:
-        """Legacy: Submit job without run tracking"""
+        """Legacy: Submit job without run tracking.
+
+        For PJM, output filenames are fixed (``job.out`` / ``job.err``)
+        because the legacy path hard-codes ``run_id="job"``; repeated
+        calls overwrite previous output. Slurm submissions still
+        disambiguate via ``%j`` substitution in the output directive.
+        """
         template = Template(JOB_TEMPLATE)
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
+        run_dir = f"{workdir}/.hpc/runs/job"
         options = (
             self.config.pjm.options
             if self.config.cluster.scheduler == "pjm"
@@ -208,6 +218,7 @@ class JobManager:
             run_id="job",
             directives=directives,
             user_directives=user_directives,
+            output_directives=self.scheduler.output_directives(run_dir),
             scheduler=self.scheduler,
             workdir=workdir,
             job_workdir=workdir,
@@ -240,8 +251,8 @@ class JobManager:
         from .ssh import SSHError
 
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
-        ext = "err" if error else "out"
-        output_path = f"{workdir}/.hpc/runs/{run_id}/job-{job_id}.{ext}"
+        run_dir = f"{workdir}/.hpc/runs/{run_id}"
+        output_path = self.scheduler.output_path(run_dir, job_id, error=error)
 
         try:
             result = self.ssh_manager.run_command("cat", [output_path])
@@ -284,8 +295,8 @@ class JobManager:
             return 0
 
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
-        ext = "err" if error else "out"
-        output_path = f"{workdir}/.hpc/runs/{run_id}/job-{job_id}.{ext}"
+        run_dir = f"{workdir}/.hpc/runs/{run_id}"
+        output_path = self.scheduler.output_path(run_dir, job_id, error=error)
         return self.ssh_manager.run_streaming("tail", ["-F", output_path])
 
     def wait_for_job(

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -69,6 +69,25 @@ class Scheduler(ABC):
     @abstractmethod
     def parse_status(self, output: str) -> JobStatus: ...
 
+    @abstractmethod
+    def output_directives(self, run_dir: str) -> list[str]:
+        """Bookkeeping directives that route the job's stdout/stderr under
+        ``run_dir``. Each scheduler's emitted path must be the one
+        ``output_path`` returns; the two methods share one source of truth
+        per scheduler so the directive write target and the JobManager read
+        target stay in sync."""
+        ...
+
+    @abstractmethod
+    def output_path(self, run_dir: str, job_id: str, error: bool = False) -> str:
+        """The on-disk path produced by ``output_directives``.
+
+        Mirrors directive semantics so ``JobManager.get_job_output`` /
+        ``tail_job_output`` can read the file back. Schedulers whose
+        directives are job-id-independent (PJM with fixed names) ignore
+        the ``job_id`` argument."""
+        ...
+
     def detail_cmd(self, job_id: str) -> list[str] | None:
         """Command that fetches detailed accounting info, or None if unsupported."""
         return None
@@ -81,6 +100,16 @@ class Scheduler(ABC):
 class Slurm(Scheduler):
     def directive_prefix(self) -> str:
         return "#SBATCH"
+
+    def output_directives(self, run_dir: str) -> list[str]:
+        return [
+            f"#SBATCH --output={run_dir}/job-%j.out",
+            f"#SBATCH --error={run_dir}/job-%j.err",
+        ]
+
+    def output_path(self, run_dir: str, job_id: str, error: bool = False) -> str:
+        ext = "err" if error else "out"
+        return f"{run_dir}/job-{job_id}.{ext}"
 
     def submit_cmd(self) -> list[str]:
         return ["sbatch", "--parsable"]
@@ -209,6 +238,23 @@ class PJM(Scheduler):
 
     def directive_prefix(self) -> str:
         return "#PJM -L"
+
+    def output_directives(self, run_dir: str) -> list[str]:
+        # pjsub's ``-o`` / ``-e`` use the path argument literally; no
+        # ``%j`` / ``%J`` substitution comparable to Slurm is part of the
+        # documented behavior, so fixed filenames are used and the caller
+        # is responsible for choosing a ``run_dir`` that disambiguates
+        # across submissions.
+        return [
+            f"#PJM -o {run_dir}/job.out",
+            f"#PJM -e {run_dir}/job.err",
+        ]
+
+    def output_path(self, run_dir: str, job_id: str, error: bool = False) -> str:
+        # ``job_id`` is not part of the path because the directive uses a
+        # literal fixed name. Accepted to match the Scheduler signature.
+        ext = "err" if error else "out"
+        return f"{run_dir}/job.{ext}"
 
     def submit_cmd(self) -> list[str]:
         return ["pjsub"]

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -99,13 +99,42 @@ class TestJobManagerSubmit:
 
         manager.submit_job("python train.py")
 
-        mkdir_calls = [
-            call
-            for call in mock_ssh_manager.run_command.call_args_list
-            if call.args[0] == "mkdir"
+        calls = mock_ssh_manager.run_command.call_args_list
+        mkdir_idx = next((i for i, c in enumerate(calls) if c.args[0] == "mkdir"), None)
+        submit_idx = next(
+            (i for i, c in enumerate(calls) if c.args[0] == "pjsub"), None
+        )
+        assert mkdir_idx is not None, "submit_job must mkdir -p its run_dir"
+        assert submit_idx is not None, "submit_job must invoke pjsub"
+        # Ordering matters: pjsub opens the directives' output paths,
+        # so the directory must exist before pjsub runs.
+        assert mkdir_idx < submit_idx
+        assert calls[mkdir_idx].args[1] == [
+            "-p",
+            "/scratch/user/proj/.hpc/runs/job",
         ]
-        assert mkdir_calls, "submit_job must mkdir -p its run_dir"
-        assert mkdir_calls[0].args[1] == [
+
+    def test_submit_job_creates_run_dir_before_submission_slurm(self, mock_ssh_manager):
+        # Same pair-invariant as the PJM variant: the contract holds for
+        # every scheduler the legacy path can target, not only PJM.
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
+            env=EnvConfig(),
+            slurm=SlurmConfig(options={"partition": "gpu"}),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
+
+        manager.submit_job("python train.py")
+
+        calls = mock_ssh_manager.run_command.call_args_list
+        mkdir_idx = next((i for i, c in enumerate(calls) if c.args[0] == "mkdir"), None)
+        submit_idx = next(
+            (i for i, c in enumerate(calls) if c.args[0] == "sbatch"), None
+        )
+        assert mkdir_idx is not None and submit_idx is not None
+        assert mkdir_idx < submit_idx
+        assert calls[mkdir_idx].args[1] == [
             "-p",
             "/scratch/user/proj/.hpc/runs/job",
         ]
@@ -152,6 +181,67 @@ class TestJobManagerSubmit:
         call_args = mock_ssh_manager.run_command.call_args
         assert call_args.args[0] == "pjsub"
         assert "--no-check-directory" in call_args.args[1]
+
+    def test_submit_run_creates_run_dir_before_submission(self, mock_ssh_manager):
+        # Pair-invariant: every submission path's rendered script directs
+        # the scheduler's stdout/stderr under ``run_dir``, so ``run_dir``
+        # must exist before the scheduler is invoked. Asserting the mkdir
+        # call protects the pair from regressing in either submission
+        # path.
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout="[INFO] PJM 0000 pjsub Job 12345678 submitted.\n"
+        )
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
+        manager.submit_run(run)
+
+        calls = mock_ssh_manager.run_command.call_args_list
+        mkdir_idx = next((i for i, c in enumerate(calls) if c.args[0] == "mkdir"), None)
+        submit_idx = next(
+            (i for i, c in enumerate(calls) if c.args[0] == "pjsub"), None
+        )
+        assert mkdir_idx is not None, "submit_run must mkdir -p its run_dir"
+        assert submit_idx is not None, "submit_run must invoke pjsub"
+        assert mkdir_idx < submit_idx
+        assert calls[mkdir_idx].args[1] == [
+            "-p",
+            "/scratch/user/proj/.hpc/runs/test_run",
+        ]
+
+    def test_submit_run_creates_run_dir_before_submission_slurm(self, mock_ssh_manager):
+        # Pair-invariant holds for Slurm submissions too.
+        config = HpcConfig(
+            cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
+            env=EnvConfig(),
+            slurm=SlurmConfig(options={"partition": "gpu"}),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="12345678\n")
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
+        manager.submit_run(run)
+
+        calls = mock_ssh_manager.run_command.call_args_list
+        mkdir_idx = next((i for i, c in enumerate(calls) if c.args[0] == "mkdir"), None)
+        submit_idx = next(
+            (i for i, c in enumerate(calls) if c.args[0] == "sbatch"), None
+        )
+        assert mkdir_idx is not None and submit_idx is not None
+        assert mkdir_idx < submit_idx
+        assert calls[mkdir_idx].args[1] == [
+            "-p",
+            "/scratch/user/proj/.hpc/runs/test_run",
+        ]
 
     def test_submit_run_includes_slurm_submit_options(self, mock_ssh_manager):
         config = HpcConfig(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -80,6 +80,36 @@ class TestJobManagerSubmit:
         assert call_args.args[0] == "pjsub"
         assert "--no-check-directory" in call_args.args[1]
 
+    def test_submit_job_creates_run_dir_before_submission(self, mock_ssh_manager):
+        # The rendered script's ``-o`` / ``--output=`` directives point
+        # under ``<workdir>/.hpc/runs/job/``; the scheduler must be able
+        # to open those paths, so the directory has to exist when pjsub /
+        # sbatch consumes the script.
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout="[INFO] PJM 0000 pjsub Job 12345678 submitted.\n"
+        )
+
+        manager.submit_job("python train.py")
+
+        mkdir_calls = [
+            call
+            for call in mock_ssh_manager.run_command.call_args_list
+            if call.args[0] == "mkdir"
+        ]
+        assert mkdir_calls, "submit_job must mkdir -p its run_dir"
+        assert mkdir_calls[0].args[1] == [
+            "-p",
+            "/scratch/user/proj/.hpc/runs/job",
+        ]
+
     def test_submit_job_includes_slurm_submit_options(self, mock_ssh_manager):
         config = HpcConfig(
             cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -244,6 +244,70 @@ class TestJobManagerTemplate:
         # Output paths still use base workdir
         assert "--output=/scratch/user/proj/.hpc/runs/test_run" in script
 
+    def test_render_job_script_pjm_emits_pjm_output_directives(self, mock_ssh_manager):
+        """PJM jobs must emit ``#PJM -o`` / ``#PJM -e`` for the bookkeeping
+        output paths, not the Slurm-shaped ``--output=`` / ``--error=``
+        that pjsub does not honor."""
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=12"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
+        script = manager._render_job_script(run)
+
+        assert "#PJM -o /scratch/user/proj/.hpc/runs/test_run/job.out" in script
+        assert "#PJM -e /scratch/user/proj/.hpc/runs/test_run/job.err" in script
+        # Disconfirming: the Slurm-shaped forms (the original bug) must
+        # not leak into a PJM-rendered script.
+        assert "--output=" not in script
+        assert "--error=" not in script
+
+
+class TestJobManagerGetJobOutput:
+    """Path resolution in ``get_job_output`` routes through
+    ``scheduler.output_path`` so PJM (fixed names) and Slurm
+    (``job-<id>`` names) both work."""
+
+    def test_pjm_uses_fixed_filename(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="hello\n")
+
+        out = manager.get_job_output("test_run", "12345678")
+
+        assert out == "hello\n"
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[0] == "cat"
+        assert call_args.args[1] == ["/scratch/user/proj/.hpc/runs/test_run/job.out"]
+
+    def test_pjm_error_flag_uses_err_extension(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="oops\n")
+
+        manager.get_job_output("test_run", "12345678", error=True)
+
+        call_args = mock_ssh_manager.run_command.call_args
+        assert call_args.args[1] == ["/scratch/user/proj/.hpc/runs/test_run/job.err"]
+
 
 class TestJobManagerTailJobOutput:
     def _running_status(self):
@@ -320,6 +384,29 @@ class TestJobManagerTailJobOutput:
 
         rc = manager.tail_job_output("run_id", "12345678")
         assert rc == 130
+
+    def test_tail_job_output_pjm_uses_fixed_filename(self, mock_ssh_manager):
+        config = HpcConfig(
+            cluster=ClusterConfig(
+                host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+            ),
+            env=EnvConfig(),
+            pjm=PjmConfig(options=[["-L", "node=1"]]),
+        )
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
+        # ``pjstat --choose st`` emits one column: header ``ST`` then the
+        # status token. Non-terminal status makes ``tail_job_output`` take
+        # the streaming path rather than falling back to ``get_job_output``.
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="ST\nRUN\n")
+        mock_ssh_manager.run_streaming.return_value = 0
+
+        rc = manager.tail_job_output("test_run", "12345678")
+
+        assert rc == 0
+        mock_ssh_manager.run_streaming.assert_called_once_with(
+            "tail",
+            ["-F", "/scratch/user/proj/.hpc/runs/test_run/job.out"],
+        )
 
 
 class TestExtractPrologueDirectives:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -316,3 +316,81 @@ class TestPJMDetailNotSupported:
 
     def test_pjm_parse_detail_returns_none(self):
         assert PJM().parse_detail("anything") is None
+
+
+class TestSlurmOutput:
+    def test_output_directives_contains_sbatch_output_and_error(self):
+        directives = Slurm().output_directives("/run")
+        assert directives == [
+            "#SBATCH --output=/run/job-%j.out",
+            "#SBATCH --error=/run/job-%j.err",
+        ]
+
+    def test_output_path_default_uses_out_extension(self):
+        assert Slurm().output_path("/run", "42") == "/run/job-42.out"
+
+    def test_output_path_error_flag_uses_err_extension(self):
+        assert Slurm().output_path("/run", "42", error=True) == "/run/job-42.err"
+
+
+class TestPJMOutput:
+    def test_output_directives_emits_pjm_o_and_e(self):
+        directives = PJM().output_directives("/run")
+        assert directives == ["#PJM -o /run/job.out", "#PJM -e /run/job.err"]
+
+    def test_output_directives_does_not_emit_slurm_form(self):
+        # Disconfirming check: a regression that re-emits Slurm-shaped
+        # ``#PJM --output=...`` / ``#PJM --error=...`` (which pjsub does
+        # not honor) trips this assertion.
+        for d in PJM().output_directives("/run"):
+            assert "--output=" not in d
+            assert "--error=" not in d
+
+    def test_output_path_default_uses_out_extension(self):
+        assert PJM().output_path("/run", "42") == "/run/job.out"
+
+    def test_output_path_error_flag_uses_err_extension(self):
+        assert PJM().output_path("/run", "42", error=True) == "/run/job.err"
+
+    def test_output_path_ignores_job_id(self):
+        # PJM directives emit a fixed name, so different job ids must
+        # resolve to the same on-disk path — keeps the directive write
+        # target and the JobManager read target in sync.
+        assert PJM().output_path("/run", "1") == PJM().output_path("/run", "999")
+
+
+class TestSchedulerOutputDirectiveContract:
+    """Each scheduler's ``output_directives`` writes to the path that
+    ``output_path`` returns — verified by substituting Slurm's ``%j``
+    placeholder into the emitted directive and asserting the result
+    matches ``output_path``."""
+
+    def _emitted_path(self, scheduler, run_dir: str, job_id: str, error: bool) -> str:
+        # Pick the directive that carries either ``--output``/``--error``
+        # (Slurm) or ``-o``/``-e`` (PJM), substitute Slurm's ``%j`` with
+        # ``job_id``, and return the path operand.
+        directives = scheduler.output_directives(run_dir)
+        wants_err = error
+        for directive in directives:
+            sub = directive.replace("%j", job_id)
+            if " --output=" in sub or sub.endswith(".out") or " -o " in sub:
+                if not wants_err:
+                    return sub.split("=", 1)[1] if "=" in sub else sub.split()[-1]
+            if " --error=" in sub or sub.endswith(".err") or " -e " in sub:
+                if wants_err:
+                    return sub.split("=", 1)[1] if "=" in sub else sub.split()[-1]
+        raise AssertionError(f"no matching directive: {directives}")
+
+    def test_slurm_directive_path_matches_output_path(self):
+        slurm = Slurm()
+        for error in (False, True):
+            assert self._emitted_path(slurm, "/run", "42", error) == slurm.output_path(
+                "/run", "42", error=error
+            )
+
+    def test_pjm_directive_path_matches_output_path(self):
+        pjm = PJM()
+        for error in (False, True):
+            assert self._emitted_path(pjm, "/run", "42", error) == pjm.output_path(
+                "/run", "42", error=error
+            )


### PR DESCRIPTION
## Summary

`JOB_TEMPLATE` in `src/hpc/job.py` hard-coded Slurm-shaped `#... --output=...` / `#... --error=...` directives for both schedulers, so PJM jobs emitted `#PJM --output=...` which pjsub does not honor. PJM stdout/stderr therefore landed at pjsub's default location (`<script>.<jobid>.out` in the workdir) instead of under `<workdir>/.hpc/runs/<run_id>/`, which is where `hpc job-output` reads from.

This change routes directive emission and path read-back through a matched pair on the `Scheduler` ABC so each scheduler owns a single source of truth for both writing and reading the bookkeeping output.

Closes #17.

## Changes

- `src/hpc/scheduler.py` — add `Scheduler.output_directives(run_dir)` and `Scheduler.output_path(run_dir, job_id, error)` as abstract methods, with concrete implementations on `Slurm` (Slurm form with `%j` substitution) and `PJM` (`-o` / `-e` with fixed `job.out` / `job.err` filenames, so the path does not depend on per-version pjsub `%j` substitution behavior).
- `src/hpc/job.py` — replace the hard-coded `--output=` / `--error=` lines in `JOB_TEMPLATE` with a Jinja loop over `output_directives`. Plumb `output_directives` through `_render_job_script` and the legacy `submit_job`. Route `get_job_output` and `tail_job_output` through `scheduler.output_path` instead of the hand-built `f"...job-{job_id}.{ext}"` literal. Add a one-line docstring note on `submit_job` flagging that the legacy path's hard-coded `run_id="job"` means PJM output filenames are reused (Slurm is unaffected because `%j` disambiguates by job id).

## Impact

- Slurm directive strings are byte-identical; no behavior change.
- PJM is the actual fix — `#PJM --output=...` becomes `#PJM -o ...`, and `JobManager.get_job_output` / `tail_job_output` resolve the new fixed path so `hpc job-output <run_id>` works for PJM submissions.
- CLI surface (`hpc submit`, `hpc job-output`) and config schema unchanged.

## Test plan

- New `TestSlurmOutput` and `TestPJMOutput` in `tests/test_scheduler.py` cover both `output_directives` and `output_path` (default and `error=True` flag) per scheduler.
- New `TestSchedulerOutputDirectiveContract` enforces the cross-method invariant: the path emitted by `output_directives(run_dir)` — with Slurm's `%j` substituted by `job_id` — equals `output_path(run_dir, job_id, error)`. This is the abstract contract the new methods' docstrings claim.
- New PJM render and read tests in `tests/test_job.py`: `test_render_job_script_pjm_emits_pjm_output_directives` (asserts `#PJM -o .../job.out` and `#PJM -e .../job.err` are emitted and Slurm-shaped `--output=` / `--error=` are absent), `test_pjm_uses_fixed_filename` / `test_pjm_error_flag_uses_err_extension` for `get_job_output`, and `test_tail_job_output_pjm_uses_fixed_filename` for the streaming path.
- Existing Slurm assertions pass unchanged because the Slurm directive string is byte-identical.
- `uv run pytest`: 228 passed (pre-change baseline 214 + 14 new).
- `uv run ruff check`: clean.
