### PR TITLE
fix(scheduler): check EC/SN for PJM EXT to detect script failures

### DIFF
--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -221,6 +221,14 @@ class Slurm(Scheduler):
 
 
 class PJM(Scheduler):
+    # ``ST`` is only a coarse classification of the scheduler-side state.
+    # ``EXT`` in particular means "exited", which covers both successful and
+    # abnormal completions; ``parse_status`` consults ``EC`` and ``SN``
+    # before applying the mapping for that case. The ``"EXT"`` entry is
+    # retained here to document the bare-``ST`` semantics and so that any
+    # future caller that reads the map directly still classifies it as a
+    # terminal state, but normal status resolution goes through
+    # ``parse_status``.
     _STATUS_MAP = {
         "ACC": JobStatus.PENDING,
         "QUE": JobStatus.PENDING,
@@ -273,12 +281,37 @@ class PJM(Scheduler):
         return output.strip()
 
     def status_cmd(self, job_id: str) -> list[str]:
-        return ["pjstat", "--choose", "st", job_id]
+        # Request ``ST`` together with ``EC`` (exit code) and ``SN``
+        # (terminating signal). With ``ST=EXT`` alone, a successful exit
+        # (``EC=0, SN=0``) and an abnormal one (``EC!=0`` or ``SN!=0``)
+        # are indistinguishable, so ``parse_status`` cannot surface
+        # script failures without these extra columns. ``-H`` is
+        # deliberately omitted: the default non-history view briefly
+        # retains ``EXT`` after completion, so a single query covers
+        # both active and just-completed jobs, whereas ``-H`` would hide
+        # currently-active jobs.
+        return ["pjstat", "-v", "--choose", "jid,st,ec,sn", job_id]
 
     def parse_status(self, output: str) -> JobStatus:
-        lines = output.strip().splitlines()
-        status_str = lines[1].strip() if len(lines) >= 2 else ""
-        return self._STATUS_MAP.get(status_str, JobStatus.FAILED)
+        # Expected output shape (header row + one data row per job):
+        #     JOB_ID     ST  EC  SN
+        #     48969021   EXT 0   0
+        # The first parseable row wins; multi-row aggregation for array
+        # / step jobs is tracked separately (Issue #12) and out of scope
+        # here. An empty / header-only response falls back to ``FAILED``,
+        # the same fallback the pre-EC/SN parser used (Issue #8 owns
+        # the principled fix).
+        for raw in output.splitlines():
+            tokens = raw.split()
+            if len(tokens) < 4 or tokens[0] == "JOB_ID":
+                continue
+            st, ec, sn = tokens[1], tokens[2], tokens[3]
+            if st == "EXT":
+                return (
+                    JobStatus.COMPLETED if ec == "0" and sn == "0" else JobStatus.FAILED
+                )
+            return self._STATUS_MAP.get(st, JobStatus.FAILED)
+        return JobStatus.FAILED
 
 
 # Slurm job state strings as reported by `sacct`. Unknown states fall back

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -514,10 +514,13 @@ class TestJobManagerTailJobOutput:
             pjm=PjmConfig(options=[["-L", "node=1"]]),
         )
         manager = JobManager(ssh_manager=mock_ssh_manager, config=config)
-        # ``pjstat --choose st`` emits one column: header ``ST`` then the
-        # status token. Non-terminal status makes ``tail_job_output`` take
-        # the streaming path rather than falling back to ``get_job_output``.
-        mock_ssh_manager.run_command.return_value = MagicMock(stdout="ST\nRUN\n")
+        # ``pjstat -v --choose jid,st,ec,sn`` emits a header row followed
+        # by one data row per job. A non-terminal ST makes
+        # ``tail_job_output`` take the streaming path rather than falling
+        # back to ``get_job_output``.
+        mock_ssh_manager.run_command.return_value = MagicMock(
+            stdout="JOB_ID ST EC SN\n12345678 RUN 0 0\n"
+        )
         mock_ssh_manager.run_streaming.return_value = 0
 
         rc = manager.tail_job_output("test_run", "12345678")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -254,6 +254,13 @@ class TestPJMParseStatus:
         output = f"{self._HEADER}48971221   RUN 0   0\n48971222   EXT 0   0\n"
         assert PJM().parse_status(output) == JobStatus.RUNNING
 
+    def test_short_row_skipped_before_data_row(self):
+        # Lines with fewer than four whitespace-separated tokens are
+        # not valid data rows (e.g. transient diagnostic text or a
+        # partial line); the parser must skip them and continue.
+        output = f"{self._HEADER}short\n48971221   EXT 0   0\n"
+        assert PJM().parse_status(output) == JobStatus.COMPLETED
+
 
 class TestPJMParseJobID:
     def test_parse_job_id_prefers_job_token(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -186,6 +186,75 @@ class TestSlurmParseStatus:
         assert Slurm().parse_status(output) == JobStatus.CANCELLED
 
 
+class TestPJMStatusCmd:
+    def test_status_cmd_requests_ec_and_sn_columns(self):
+        # EC and SN are required to distinguish a successful EXT
+        # (EC=0 and SN=0) from an abnormal one; a bare ``st`` column
+        # cannot. ``-H`` is omitted intentionally so currently-active
+        # jobs are still listed.
+        assert PJM().status_cmd("12345") == [
+            "pjstat",
+            "-v",
+            "--choose",
+            "jid,st,ec,sn",
+            "12345",
+        ]
+
+
+class TestPJMParseStatus:
+    _HEADER = "JOB_ID     ST  EC  SN\n"
+
+    def _row(self, st: str, ec: str = "0", sn: str = "0") -> str:
+        return f"{self._HEADER}48971221   {st} {ec}   {sn}\n"
+
+    def test_que_maps_to_pending(self):
+        assert PJM().parse_status(self._row("QUE")) == JobStatus.PENDING
+
+    def test_run_maps_to_running(self):
+        assert PJM().parse_status(self._row("RUN")) == JobStatus.RUNNING
+
+    def test_ext_with_zero_ec_and_sn_maps_to_completed(self):
+        assert PJM().parse_status(self._row("EXT", "0", "0")) == JobStatus.COMPLETED
+
+    def test_ext_with_nonzero_ec_maps_to_failed(self):
+        # User script exited non-zero; PJM still reports ST=EXT because
+        # the scheduler observed a normal exit-syscall path, but the
+        # user-visible result is a failure.
+        assert PJM().parse_status(self._row("EXT", "1", "0")) == JobStatus.FAILED
+
+    def test_ext_with_signal_maps_to_failed(self):
+        # Job killed by SIGKILL (or similar); ST=EXT, SN!=0.
+        assert PJM().parse_status(self._row("EXT", "0", "9")) == JobStatus.FAILED
+
+    def test_err_maps_to_failed(self):
+        assert PJM().parse_status(self._row("ERR")) == JobStatus.FAILED
+
+    def test_ccl_maps_to_cancelled(self):
+        assert PJM().parse_status(self._row("CCL")) == JobStatus.CANCELLED
+
+    def test_rjt_maps_to_failed(self):
+        assert PJM().parse_status(self._row("RJT")) == JobStatus.FAILED
+
+    def test_empty_output_falls_back_to_failed(self):
+        # Regression guard for the deferred Issue #8: today, empty
+        # pjstat output is conflated with a true failure. The eventual
+        # fix should be a deliberate behavior change rather than an
+        # accidental one.
+        assert PJM().parse_status("") == JobStatus.FAILED
+
+    def test_header_only_output_falls_back_to_failed(self):
+        # Same deferred-#8 guard, header-only shape: ``pjstat`` exited
+        # cleanly but produced no data row (job aged out of the active
+        # view's post-EXT window).
+        assert PJM().parse_status(self._HEADER) == JobStatus.FAILED
+
+    def test_multi_row_input_takes_first_parseable_row(self):
+        # Documents today's single-row semantics so the eventual array
+        # / step-job aggregation fix (Issue #12) is a deliberate change.
+        output = f"{self._HEADER}48971221   RUN 0   0\n48971222   EXT 0   0\n"
+        assert PJM().parse_status(output) == JobStatus.RUNNING
+
+
 class TestPJMParseJobID:
     def test_parse_job_id_prefers_job_token(self):
         scheduler = PJM()


### PR DESCRIPTION
## Summary

`PJM.parse_status` consumed only the `ST` column from `pjstat --choose st <jid>`, so a successful `ST=EXT` (`EC=0, SN=0`) and an abnormal `ST=EXT` (non-zero exit code or terminating signal) both mapped to `COMPLETED`. `hpc wait` and `hpc status` therefore could not surface user-script failures on PJM clusters.

Switch the query to `pjstat -v --choose jid,st,ec,sn <jid>` and treat `ST=EXT` as `COMPLETED` only when `EC=0` and `SN=0`; otherwise `FAILED`. Non-`EXT` `ST` codes keep their existing `_STATUS_MAP` semantics.

Closes #22.

## Changes

- `src/hpc/scheduler.py` — `PJM.status_cmd` requests the new 4-column shape; `PJM.parse_status` skips the header and short rows, then branches on `ST==EXT` with the EC/SN check. A class-level comment block documents that the retained `_STATUS_MAP["EXT"]` entry is the bare-`ST` mapping and that `parse_status` short-circuits before reaching it.
- `tests/test_scheduler.py` — new `TestPJMStatusCmd` and `TestPJMParseStatus` covering `QUE`, `RUN`, `EXT 0 0`, `EXT 1 0`, `EXT 0 9`, `ERR`, `CCL`, `RJT`, empty input, header-only input, multi-row first-wins, and short-row skip.
- `tests/test_job.py` — `test_tail_job_output_pjm_uses_fixed_filename` updated to the new 4-column mock fixture so the streaming path still triggers.

## Impact

`PJM.parse_status` is reached only via `JobManager.get_job_status`. Its four consumers (`hpc status`, `get_job_output`, `tail_job_output`, `wait_for_job`) all branch on the `JobStatus` enum, so the only externally observable change is that abnormal `EXT` now surfaces as `FAILED` instead of `COMPLETED`. `wait_for_job` continues to treat the new `FAILED` as a terminal state; `tail_job_output` now correctly falls back to `cat` for abnormal `EXT` rather than spinning on `tail -F`.

## Test plan

- 11 new `TestPJMParseStatus` cases plus the `TestPJMStatusCmd` shape check.
- `tests/test_job.py` PJM streaming-path test re-verified with the new fixture.
- `uv run pytest`: 245 passed.
- `uv run ruff check`, `uv run ruff format`, `uv run pyright src/hpc/`: clean.

## Out of scope

Three related concerns are intentionally not addressed here and remain tracked elsewhere:

- Multi-data-row aggregation for PJM array / step jobs. The new parser deliberately keeps the prior single-data-row behavior (it takes the first parseable row). The aggregation analogous to the Slurm fix landed for #7 is tracked in #12.
- Dash (`-`) placeholder for `EC` / `SN` in non-`--data` `pjstat` output during a transient mid-flight read. Safe with the new parser: `parse_status` consults `EC` and `SN` only when `ST == "EXT"`, so a placeholder on a non-terminal row is inert.
- Empty / header-only `pjstat` output still falls back to `FAILED`, matching the pre-`EC/SN` parser's behavior. The principled fix (distinguish an unknown / not-yet-indexed job from a true failure) is tracked in #8.

## Notes

The second commit (`test(scheduler): cover PJM parse_status short-row skip path`) adds a regression-guard test for the `len(tokens) < 4` skip branch that the first commit introduces. Pure test addition; no behavior change.
