### PR TITLE
fix(ssh): include exit code, command, and both streams in SSHError

### DIFF
--- a/src/hpc/ssh.py
+++ b/src/hpc/ssh.py
@@ -121,7 +121,17 @@ class SSHManager:
         )
 
         if result.returncode != 0:
-            raise SSHError(f"SSH command failed: {result.stderr}")
+            # Include exit code, the executed remote command, and both
+            # streams so tools that emit diagnostics on stdout (e.g. pjsub
+            # rejections, anything printing `[ERR.] ...` on stdout) are
+            # not silently swallowed. Empty sections are omitted to keep
+            # the common stderr-only case readable.
+            parts = [f"SSH command failed (exit {result.returncode}): {command}"]
+            if result.stdout:
+                parts.append(f"stdout:\n{result.stdout.rstrip()}")
+            if result.stderr:
+                parts.append(f"stderr:\n{result.stderr.rstrip()}")
+            raise SSHError("\n".join(parts))
 
         return CommandResult(
             returncode=result.returncode,

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -452,7 +452,10 @@ class TestJobManagerGetJobOutput:
         # diagnostic, not the inner accounting-not-ready one.
         manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
         mock_ssh_manager.run_command.side_effect = [
-            SSHError("SSH command failed: cat: No such file or directory"),
+            SSHError(
+                "SSH command failed (exit 1): cat /scratch/user/proj/.hpc/runs/test_run/job-12345678.out\n"
+                "stderr:\ncat: No such file or directory"
+            ),
             MagicMock(stdout=""),  # status probe; parse_status raises SchedulerError
         ]
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -83,6 +83,78 @@ class TestSSHManagerRunCommand:
             with pytest.raises(SSHError):
                 manager.run_command("echo", ["hello"])
 
+    def test_run_command_failure_includes_exit_code_and_command(self):
+        # The message always contains the exit code and the executed
+        # remote command so callers can locate which invocation failed
+        # without re-running with extra logging.
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=42, stdout="", stderr="boom")
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("echo", ["hello"])
+            msg = str(exc_info.value)
+            assert msg.startswith("SSH command failed (exit 42):")
+            assert "echo hello" in msg
+
+    def test_run_command_failure_with_only_stderr_omits_stdout_section(self):
+        # Typical SSH-transport / cat-missing-file failure: only stderr
+        # carries the diagnostic. The empty stdout section must be
+        # omitted so the message stays readable.
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="cat: /missing: No such file or directory\n",
+            )
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("cat", ["/missing"])
+            msg = str(exc_info.value)
+            assert "stderr:\ncat: /missing: No such file or directory" in msg
+            assert "stdout:" not in msg
+
+    def test_run_command_failure_with_only_stdout_surfaces_it(self):
+        # pjsub rejections and other tools that emit error text on stdout
+        # used to vanish behind an empty trailing colon. The enriched
+        # message must include the stdout section so the diagnostic is
+        # visible to the caller.
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="[ERR.] PJM 0000 pjsub Invalid option specified\n",
+                stderr="",
+            )
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("pjsub", ["bad.sh"])
+            msg = str(exc_info.value)
+            assert "stdout:\n[ERR.] PJM 0000 pjsub Invalid option specified" in msg
+            assert "stderr:" not in msg
+
+    def test_run_command_failure_with_both_streams_includes_both(self):
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=2, stdout="partial output\n", stderr="warning then error\n"
+            )
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("some_cmd")
+            msg = str(exc_info.value)
+            assert "stdout:\npartial output" in msg
+            assert "stderr:\nwarning then error" in msg
+
+    def test_run_command_failure_with_empty_streams_keeps_command_and_code(self):
+        # Boundary case: command failed but produced no output. The
+        # message must still be informative — exit code and command name
+        # remain — even though there is nothing else to surface.
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=255, stdout="", stderr="")
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("hostname")
+            msg = str(exc_info.value)
+            assert msg == "SSH command failed (exit 255): hostname"
+
     def test_run_command_captures_stderr(self):
         manager = SSHManager(host="myhpc")
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

`SSHManager.run_command` attached only `result.stderr` to the raised `SSHError`, so remote tools that emit diagnostics on stdout (`pjsub` rejections, anything printing `[ERR.] ...` / `Error:` on stdout) collapsed the message to `SSH command failed:` with an empty trailing payload and the actual diagnostic discarded. The visibility gap was surfaced during the #17 investigation into PJM directive emission; #20 fixed the directive bug, but the underlying error-message gap remained and would mask any future remote-command failure whose tool emits its error on stdout.

The fix enriches the `SSHError` message with the exit code, the executed remote command, and any non-empty stdout / stderr sections. The `"SSH command failed"` prefix is preserved verbatim so any caller that may grep for it is unaffected.

Closes #21.

## Changes

- `src/hpc/ssh.py` — `run_command` builds the failure message from a list of parts: always include `SSH command failed (exit {rc}): {command}`; append `stdout:\n...` only when stdout is non-empty; append `stderr:\n...` only when stderr is non-empty.
- `tests/test_ssh.py` — five new tests pin the new behavior (exit-code + command prefix, stderr-only, stdout-only, both, empty boundary).
- `tests/test_job.py` — update the existing `test_inner_scheduler_error_does_not_mask_original_no_such_file` mock fixture so the synthesized `SSHError` reflects the new message format rather than the old single-colon shape.

## Impact

| Caller                                                                                      | How affected                                                                 |
| ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| `src/hpc/job.py` `if "No such file" in str(e):` (`get_job_output`)                          | unchanged — the substring continues to appear inside the stderr section      |
| Other `JobManager` catch-only sites (`wait_for_job`, `tail_job_output`, inner status probe) | unchanged — they catch without inspecting the message                        |
| CLI surfaces that let `SSHError` propagate (`hpc submit` / `hpc exec` / `hpc sync`)         | user-visible error message becomes richer (exit code, command, both streams) |

`SchedulerError` (the `SSHError` subclass added in #25, now merged on `main`) is unaffected — its message is constructed inside `src/hpc/scheduler.py::parse_status` and bypasses the `run_command` raise site touched here.

## Test plan

Invariants verified:

- (I1) The message always begins with `SSH command failed`.
- (I2) The exit code is included as a numeric literal.
- (I3) The executed remote command string is included.
- (I4) Empty stdout / stderr sections are omitted.
- (I5) Non-empty stdout / stderr sections each appear with their own header line.

Verification: `uv run pytest -q` → 256 passed (was 251; +5 new tests in `test_ssh.py`). `uv run ruff check` / `uv run ruff format --check` clean.

## Follow-ups

The implementation plan deferred two related items that this PR deliberately leaves out of scope:

- **Structured fields** (`cmd`, `returncode`, `stdout`, `stderr`) on the `SSHError` class for programmatic branching. No in-tree caller currently needs programmatic access; the single string-match site works against the enriched message, and adding consumer-less fields would be dead-on-arrival surface.
- **Apply the same enrichment to `run_streaming`** (raise on non-zero exit instead of returning the code silently). `run_streaming` is a stream-to-terminal path whose callers consume the integer return code; switching to a raised `SSHError` would change that contract and needs its own design.

Either follow-up can be filed if a consumer materializes.

## Notes

Full implementation plan (Changes, Impact, Test plan, deferred follow-ups): https://github.com/ultimatile/hpc/issues/21#issuecomment-4561921588
