### PR TITLE
feat(job): bound wait_for_job retries and add PJM history fallback

### DIFF
--- a/src/hpc/cli.py
+++ b/src/hpc/cli.py
@@ -339,7 +339,12 @@ def submit(
         status = job_manager.wait_for_job(job_id, adaptive=True)
         run.status = status.value.lower()
         run_manager.save_run_meta(run)
-        print(f"Job finished: {status.value}")
+        if status == JobStatus.UNKNOWN:
+            print(
+                f"Job {job_id}: final state unknown (scheduler stopped returning data)"
+            )
+        else:
+            print(f"Job finished: {status.value}")
         if status != JobStatus.COMPLETED:
             raise typer.Exit(1)
 
@@ -519,6 +524,11 @@ def wait(id: str, config: ConfigOption = None):
     status = job_manager.wait_for_job(run.job_id, adaptive=True)
     run.status = status.value.lower()
     run_manager.save_run_meta(run)
-    print(f"Job finished: {status.value}")
+    if status == JobStatus.UNKNOWN:
+        print(
+            f"Job {run.job_id}: final state unknown (scheduler stopped returning data)"
+        )
+    else:
+        print(f"Job finished: {status.value}")
     if status != JobStatus.COMPLETED:
         raise typer.Exit(1)

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -8,7 +8,7 @@ from jinja2 import Template
 from .config import HpcConfig
 from .ssh import SSHManager
 from .run import RunConfig
-from .scheduler import JobDetail, JobStatus, get_scheduler
+from .scheduler import JobDetail, JobStatus, SchedulerError, get_scheduler
 
 
 def _resolve_home_path(ssh_manager, path: str) -> str:
@@ -237,10 +237,27 @@ class JobManager:
         return self.scheduler.parse_job_id(result.stdout)
 
     def get_job_status(self, job_id: str) -> JobStatus:
-        """Get job status"""
+        """Get job status.
+
+        On a ``SchedulerError`` from the primary status command (no data
+        row — a fresh job not yet indexed, or one aged out of the active
+        view), try the scheduler's optional fallback command once before
+        surfacing the absence. The fallback output is parsed with
+        ``job_id`` so a differing column layout fails closed (re-raises
+        ``SchedulerError``) instead of being misread as a real status.
+        Never returns ``JobStatus.UNKNOWN`` — that terminal interpretation
+        belongs to ``wait_for_job`` once its retry budget is exhausted.
+        """
         cmd = self.scheduler.status_cmd(job_id)
         result = self.ssh_manager.run_command(cmd[0], cmd[1:])
-        return self.scheduler.parse_status(result.stdout)
+        try:
+            return self.scheduler.parse_status(result.stdout)
+        except SchedulerError:
+            fallback = self.scheduler.status_fallback_cmd(job_id)
+            if fallback is None:
+                raise
+            result = self.ssh_manager.run_command(fallback[0], fallback[1:])
+            return self.scheduler.parse_status(result.stdout, job_id=job_id)
 
     def get_job_detail(self, job_id: str) -> JobDetail | None:
         """Get detailed accounting info, or None if the scheduler does not support it."""
@@ -310,6 +327,7 @@ class JobManager:
         adaptive: bool = False,
         max_interval: float = 300,
         growth_factor: float = 2.0,
+        max_missing_polls: int = 10,
     ) -> JobStatus:
         """Wait for job to complete, polling at interval
 
@@ -319,12 +337,22 @@ class JobManager:
             adaptive: If True, increase interval geometrically
             max_interval: Maximum polling interval (default 5 minutes)
             growth_factor: Multiplier for adaptive interval (default 2x)
+            max_missing_polls: Consecutive polls with no scheduler data
+                (``SchedulerError``) tolerated before giving up and
+                returning ``JobStatus.UNKNOWN``. Bounds the otherwise
+                unbounded retry on persistently-empty status output — a
+                never-submitted job, or a PJM job aged out of every view.
+                The counter resets on any successful status read, so it
+                does not trip on transient accounting lag. Generic
+                (non-``SchedulerError``) ``SSHError`` does not count and
+                is retried without bound, as before.
         """
         import time
 
         from .ssh import SSHError
 
         current_interval = interval
+        consecutive_missing = 0
         terminal_states = {
             JobStatus.COMPLETED,
             JobStatus.FAILED,
@@ -337,16 +365,24 @@ class JobManager:
 
             try:
                 status = self.get_job_status(job_id)
+            except SchedulerError:
+                # No data row even after any fallback. Bound the retry so
+                # a never-indexed / aged-out job cannot hang the caller
+                # forever; a real terminal state is unrecoverable here.
+                consecutive_missing += 1
+                if consecutive_missing >= max_missing_polls:
+                    return JobStatus.UNKNOWN
             except SSHError:
-                # Transient SSH failures (e.g. bastion rate limiting); retry
-                if adaptive:
-                    current_interval = min(
-                        current_interval * growth_factor, max_interval
-                    )
-                continue
-
-            if status in terminal_states:
-                return status
+                # Transient SSH failures (e.g. bastion rate limiting);
+                # retry without bound and without counting toward the
+                # missing-data budget.
+                pass
+            else:
+                # A successful read clears the missing-data streak so the
+                # budget only fires on *persistent* absence.
+                consecutive_missing = 0
+                if status in terminal_states:
+                    return status
 
             if adaptive:
                 current_interval = min(current_interval * growth_factor, max_interval)

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -245,19 +245,37 @@ class JobManager:
         surfacing the absence. The fallback output is parsed with
         ``job_id`` so a differing column layout fails closed (re-raises
         ``SchedulerError``) instead of being misread as a real status.
+
+        The fallback is best-effort: if it recovers nothing — whether
+        because its command exits non-zero (an unknown/expired job id
+        raising ``SSHError``) or its output has no matching row (raising
+        ``SchedulerError``) — the original ``SchedulerError`` is surfaced
+        rather than a generic ``SSHError``. That keeps the absence within
+        ``wait_for_job``'s bounded retry budget instead of letting a
+        failed fallback escape it as an unbounded transport retry.
+
         Never returns ``JobStatus.UNKNOWN`` — that terminal interpretation
         belongs to ``wait_for_job`` once its retry budget is exhausted.
         """
+        from .ssh import SSHError
+
         cmd = self.scheduler.status_cmd(job_id)
         result = self.ssh_manager.run_command(cmd[0], cmd[1:])
         try:
             return self.scheduler.parse_status(result.stdout)
-        except SchedulerError:
+        except SchedulerError as primary_absence:
             fallback = self.scheduler.status_fallback_cmd(job_id)
             if fallback is None:
                 raise
-            result = self.ssh_manager.run_command(fallback[0], fallback[1:])
-            return self.scheduler.parse_status(result.stdout, job_id=job_id)
+            try:
+                result = self.ssh_manager.run_command(fallback[0], fallback[1:])
+                return self.scheduler.parse_status(result.stdout, job_id=job_id)
+            except SSHError:
+                # SSHError covers both the fallback command's non-zero exit
+                # and parse_status's SchedulerError (a subclass). Either way
+                # no status was recovered, so re-surface the original
+                # absence to keep wait_for_job's budget in effect.
+                raise primary_absence from None
 
     def get_job_detail(self, job_id: str) -> JobDetail | None:
         """Get detailed accounting info, or None if the scheduler does not support it."""

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -20,14 +20,18 @@ class SchedulerError(SSHError):
     callers retry / fall through instead of treating the absence of
     information as a terminal failure.
 
-    Inherits from ``SSHError`` so the three existing transient-catch
-    sites in ``JobManager`` cover it without modification:
-    ``wait_for_job``'s polling loop (continues), ``tail_job_output``'s
-    pre-tail status probe (falls through to ``tail -F``), and the inner
-    status probe inside ``get_job_output`` (swallows so the original
-    "No such file" diagnostic re-raises). CLI surfaces that want to
-    discriminate "no data yet" from a real SSH / command failure catch
-    ``SchedulerError`` specifically before the generic ``SSHError``.
+    Inherits from ``SSHError`` so the transient-catch sites in
+    ``JobManager`` cover it. ``get_job_status`` catches it to try the
+    scheduler's ``status_fallback_cmd`` (e.g. PJM's history view) before
+    surfacing the absence. ``wait_for_job`` catches it to apply a bounded
+    retry budget — persistent absence terminates as ``JobStatus.UNKNOWN``
+    rather than looping forever, while transient absence keeps polling.
+    ``tail_job_output``'s pre-tail status probe falls through to
+    ``tail -F``, and the inner status probe inside ``get_job_output``
+    swallows it so the original "No such file" diagnostic re-raises. CLI
+    surfaces that want to discriminate "no data yet" from a real SSH /
+    command failure catch ``SchedulerError`` specifically before the
+    generic ``SSHError``.
     """
 
 
@@ -38,6 +42,14 @@ class JobStatus(Enum):
     FAILED = "FAILED"
     CANCELLED = "CANCELLED"
     TIMEOUT = "TIMEOUT"
+    # Synthesized only by ``JobManager.wait_for_job`` when the scheduler
+    # produces no usable status output for a bounded number of consecutive
+    # polls (a never-indexed / never-submitted job, or a PJM job that aged
+    # out of every view). It is never returned by ``parse_status`` /
+    # ``get_job_status``, which raise ``SchedulerError`` for that absence
+    # instead; UNKNOWN is the terminal interpretation the polling loop
+    # applies once the retry budget is exhausted.
+    UNKNOWN = "UNKNOWN"
 
 
 @dataclass
@@ -92,7 +104,26 @@ class Scheduler(ABC):
     def status_cmd(self, job_id: str) -> list[str]: ...
 
     @abstractmethod
-    def parse_status(self, output: str) -> JobStatus: ...
+    def parse_status(self, output: str, job_id: str | None = None) -> JobStatus:
+        """Map status-command output to a ``JobStatus``.
+
+        ``job_id`` is optional and, when given, lets a scheduler whose
+        output carries a job-id column reject rows that do not belong to
+        the requested job — a fail-closed guard for the fallback path
+        (see ``status_fallback_cmd``). Schedulers whose output has no
+        job-id column ignore it. Raise ``SchedulerError`` when no usable
+        data row is present."""
+        ...
+
+    def status_fallback_cmd(self, job_id: str) -> list[str] | None:
+        """Secondary status command, tried only when the primary
+        ``status_cmd`` output yields no data row (``SchedulerError``).
+
+        Returns ``None`` when the scheduler has no fallback source, which
+        leaves the primary ``SchedulerError`` to propagate unchanged. The
+        fallback output is parsed with the requested ``job_id`` so a
+        differing column layout cannot be misread as a real status."""
+        return None
 
     @abstractmethod
     def output_directives(self, run_dir: str) -> list[str]:
@@ -160,7 +191,10 @@ class Slurm(Scheduler):
             "-X",
         ]
 
-    def parse_status(self, output: str) -> JobStatus:
+    def parse_status(self, output: str, job_id: str | None = None) -> JobStatus:
+        # ``sacct --format=State`` output has no job-id column, so the
+        # ``job_id`` argument (accepted for the Scheduler contract) is
+        # unused here.
         # Aggregate over all rows so an array job is reported as terminal
         # only once every task is terminal. A single non-terminal task in
         # the set must keep the aggregate non-terminal to prevent
@@ -322,7 +356,17 @@ class PJM(Scheduler):
         # currently-active jobs.
         return ["pjstat", "-v", "--choose", "jid,st,ec,sn", job_id]
 
-    def parse_status(self, output: str) -> JobStatus:
+    def status_fallback_cmd(self, job_id: str) -> list[str] | None:
+        # When the active view (``status_cmd``) has no row — a job that
+        # aged out of it after ``EXT`` — the history view (``-H``) may
+        # still hold the record. Tried only on the ``SchedulerError``
+        # path, so the extra round-trip never burdens the normal query.
+        # Same ``--choose`` columns as the primary command, so the same
+        # ``parse_status`` applies; the caller passes ``job_id`` so a
+        # differing ``-H`` layout fails closed rather than misreporting.
+        return ["pjstat", "-H", "-v", "--choose", "jid,st,ec,sn", job_id]
+
+    def parse_status(self, output: str, job_id: str | None = None) -> JobStatus:
         # Expected output shape (header row + one data row per job):
         #     JOB_ID     ST  EC  SN
         #     48969021   EXT 0   0
@@ -331,9 +375,18 @@ class PJM(Scheduler):
         # here. An empty / header-only / short-row-only response raises
         # ``SchedulerError`` so callers can distinguish "no data yet"
         # from a real terminal failure.
+        #
+        # When ``job_id`` is given (the fallback path), a row is trusted
+        # only if its first column — the ``jid`` selected via ``--choose``
+        # — equals the requested id. This fails closed: a history view
+        # whose columns drift yields no matching row and raises
+        # ``SchedulerError`` instead of mapping an unrelated column to a
+        # bogus terminal status.
         for raw in output.splitlines():
             tokens = raw.split()
             if len(tokens) < 4 or tokens[0] == "JOB_ID":
+                continue
+            if job_id is not None and tokens[0] != job_id:
                 continue
             st, ec, sn = tokens[1], tokens[2], tokens[3]
             if st == "EXT":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -412,6 +412,54 @@ def test_status_normalizes_decorated_cancelled_state(cli_runner, temp_dir, monke
     assert "MaxRSS:   -" in result.stdout
 
 
+def test_wait_reports_unknown_state_and_exits_nonzero(
+    cli_runner, temp_dir, monkeypatch
+):
+    """Issue #24: when wait_for_job exhausts its retry budget it returns
+    JobStatus.UNKNOWN; the CLI prints an explicit unknown-state line,
+    persists the run as ``unknown``, and exits non-zero."""
+    from hpc.job import JobStatus
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    run = MagicMock()
+    run.run_id = "test_run"
+    run.job_id = "12345678"
+
+    with (
+        patch("hpc.cli.JobManager") as MockJobManager,
+        patch("hpc.cli.RunManager") as MockRunManager,
+    ):
+        MockRunManager.return_value.load_run_meta.return_value = run
+        MockJobManager.return_value.wait_for_job.return_value = JobStatus.UNKNOWN
+        result = cli_runner.invoke(app, ["wait", "test_run"])
+
+    assert result.exit_code == 1
+    assert "final state unknown" in result.stdout
+    assert run.status == "unknown"
+
+
+def test_submit_wait_reports_unknown_state_and_exits_nonzero(
+    cli_runner, temp_dir, monkeypatch
+):
+    """The submit ``--wait`` path shares the same UNKNOWN handling as the
+    standalone ``wait`` command."""
+    from hpc.job import JobStatus
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.submit_run.return_value = "12345678"
+        instance.wait_for_job.return_value = JobStatus.UNKNOWN
+        result = cli_runner.invoke(app, ["submit", "python train.py", "--wait"])
+
+    assert result.exit_code == 1
+    assert "final state unknown" in result.stdout
+
+
 def test_config_option(cli_runner, temp_dir, monkeypatch):
     """Test --config option loads specified config file"""
     monkeypatch.chdir(temp_dir)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -27,6 +27,17 @@ def sample_config():
     )
 
 
+@pytest.fixture
+def pjm_config():
+    return HpcConfig(
+        cluster=ClusterConfig(
+            host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+        ),
+        env=EnvConfig(),
+        pjm=PjmConfig(options=[["-L", "node=1"]]),
+    )
+
+
 class TestJobStatus:
     def test_job_status_values(self):
         assert JobStatus.PENDING.value == "PENDING"
@@ -299,6 +310,60 @@ class TestJobManagerStatus:
         # transient-handling callers still catch it via `except SSHError`.
         manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
         mock_ssh_manager.run_command.return_value = MagicMock(stdout="")
+
+        with pytest.raises(SchedulerError):
+            manager.get_job_status("12345678")
+        # Slurm has no fallback command, so the absence surfaces after a
+        # single status call rather than triggering a second round-trip.
+        assert mock_ssh_manager.run_command.call_count == 1
+
+    def test_get_job_status_pjm_falls_back_to_history_on_empty_active_view(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # Issue #24: a PJM job that aged out of the active pjstat view may
+        # still be recoverable from the history (-H) view. get_job_status
+        # tries the fallback only after the primary returns no data row.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),  # active view: aged out -> SchedulerError
+            MagicMock(stdout="JOB_ID     ST  EC  SN\n12345678   EXT 0   0\n"),
+        ]
+
+        status = manager.get_job_status("12345678")
+        assert status == JobStatus.COMPLETED
+        assert mock_ssh_manager.run_command.call_count == 2
+        fallback_call = mock_ssh_manager.run_command.call_args_list[1]
+        assert fallback_call.args[0] == "pjstat"
+        assert "-H" in fallback_call.args[1]
+
+    def test_get_job_status_pjm_raises_when_history_also_empty(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # Never-indexed / never-submitted: neither view has a row, so the
+        # absence still surfaces as SchedulerError for wait_for_job's
+        # bounded-retry budget to terminate.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),
+            MagicMock(stdout=""),
+        ]
+
+        with pytest.raises(SchedulerError):
+            manager.get_job_status("12345678")
+        assert mock_ssh_manager.run_command.call_count == 2
+
+    def test_get_job_status_pjm_history_fallback_fails_closed_on_jid_mismatch(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # Fail-closed guard: if the -H view's column layout drifts so the
+        # first column is not the requested jid, the fallback parse finds
+        # no matching row and raises SchedulerError rather than mapping an
+        # unrelated column to a bogus terminal status.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),
+            MagicMock(stdout="JOB_ID     ST  EC  SN\n99999999   EXT 0   0\n"),
+        ]
 
         with pytest.raises(SchedulerError):
             manager.get_job_status("12345678")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -368,6 +368,24 @@ class TestJobManagerStatus:
         with pytest.raises(SchedulerError):
             manager.get_job_status("12345678")
 
+    def test_get_job_status_pjm_fallback_command_failure_surfaces_scheduler_error(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # If the fallback command itself exits non-zero (an unknown/expired
+        # job id), run_command raises a generic SSHError. get_job_status
+        # must re-surface the original SchedulerError so wait_for_job's
+        # bounded budget still applies; a leaked generic SSHError would be
+        # retried without bound and hang the caller.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),  # active view: no row -> SchedulerError
+            SSHError("pjstat -H exited non-zero"),  # history view: command error
+        ]
+
+        with pytest.raises(SchedulerError):
+            manager.get_job_status("12345678")
+        assert mock_ssh_manager.run_command.call_count == 2
+
 
 class TestJobManagerDetail:
     def test_get_job_detail_slurm_invokes_sacct_and_returns_detail(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -274,6 +274,21 @@ class TestPJMParseStatus:
         # raises SchedulerError.
         assert PJM().parse_status(self._row("ZZZ")) == JobStatus.FAILED
 
+    def test_parse_status_with_matching_job_id(self):
+        # The fallback (history) path passes job_id so only a row whose
+        # jid column matches is trusted. A matching row parses normally.
+        assert (
+            PJM().parse_status(self._row("EXT", "0", "0"), job_id="48971221")
+            == JobStatus.COMPLETED
+        )
+
+    def test_parse_status_with_mismatching_job_id_raises(self):
+        # Fail-closed: a row whose jid column does not match the requested
+        # id is skipped, so a layout-drifted history view yields no usable
+        # row and raises rather than returning a status for another job.
+        with pytest.raises(SchedulerError):
+            PJM().parse_status(self._row("EXT", "0", "0"), job_id="00000000")
+
 
 class TestSchedulerErrorInheritance:
     def test_scheduler_error_is_ssh_error_subclass(self):

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -6,7 +6,13 @@ import pytest
 
 from hpc.job import JobManager, JobStatus
 from hpc.ssh import SSHError, SSHManager
-from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig
+from hpc.config import (
+    HpcConfig,
+    ClusterConfig,
+    EnvConfig,
+    PjmConfig,
+    SlurmConfig,
+)
 
 
 @pytest.fixture
@@ -20,6 +26,17 @@ def sample_config():
         cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
         env=EnvConfig(),
         slurm=SlurmConfig(partition="gpu", time="02:00:00", mem="32G"),
+    )
+
+
+@pytest.fixture
+def pjm_config():
+    return HpcConfig(
+        cluster=ClusterConfig(
+            host="myhpc", workdir="/scratch/user/proj", scheduler="pjm"
+        ),
+        env=EnvConfig(),
+        pjm=PjmConfig(options=[["-L", "node=1"]]),
     )
 
 
@@ -139,4 +156,28 @@ class TestJobManagerWait:
 
         status = manager.wait_for_job("12345678", interval=0.01, max_missing_polls=3)
         assert status == JobStatus.COMPLETED
+        assert mock_ssh_manager.run_command.call_count == 6
+
+    def test_wait_terminates_when_pjm_fallback_command_keeps_failing(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # End-to-end termination contract: when the PJM active view is
+        # persistently empty and the history fallback command itself keeps
+        # exiting non-zero (an unknown/expired job), the wait must still
+        # terminate as UNKNOWN. The fallback's generic SSHError is folded
+        # back into SchedulerError by get_job_status so it stays inside the
+        # budget instead of being retried without bound. Each poll issues
+        # two run_command calls (active view + history fallback).
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),  # poll 1: active view empty
+            SSHError("pjstat -H exited non-zero"),  # poll 1: fallback errors
+            MagicMock(stdout=""),  # poll 2
+            SSHError("pjstat -H exited non-zero"),
+            MagicMock(stdout=""),  # poll 3
+            SSHError("pjstat -H exited non-zero"),
+        ]
+
+        status = manager.wait_for_job("12345678", interval=0.01, max_missing_polls=3)
+        assert status == JobStatus.UNKNOWN
         assert mock_ssh_manager.run_command.call_count == 6

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hpc.job import JobManager, JobStatus
-from hpc.ssh import SSHManager
+from hpc.ssh import SSHError, SSHManager
 from hpc.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig
 
 
@@ -85,3 +85,58 @@ class TestJobManagerWait:
             # Interval should increase
             intervals = [c[0][0] for c in mock_sleep.call_args_list]
             assert intervals[1] >= intervals[0]
+
+    def test_wait_gives_up_after_max_missing_polls(
+        self, mock_ssh_manager, sample_config
+    ):
+        # Issue #24: persistently-empty status output (never-submitted job,
+        # or a PJM job aged out of every view) must terminate the wait
+        # instead of looping forever. The bounded retry surfaces it as
+        # JobStatus.UNKNOWN once the budget is exhausted.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.return_value = MagicMock(stdout="")
+
+        status = manager.wait_for_job("12345678", interval=0.01, max_missing_polls=3)
+        assert status == JobStatus.UNKNOWN
+        assert mock_ssh_manager.run_command.call_count == 3
+
+    def test_wait_missing_budget_resets_on_successful_read(
+        self, mock_ssh_manager, sample_config
+    ):
+        # The budget counts only *consecutive* empty polls: a successful
+        # read in between clears the streak, so transient accounting lag
+        # interleaved with real status never trips the limit.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = [
+            MagicMock(stdout=""),  # missing 1
+            MagicMock(stdout=""),  # missing 2 (budget is 3, not yet hit)
+            MagicMock(stdout="RUNNING\n"),  # success -> reset to 0
+            MagicMock(stdout=""),  # missing 1
+            MagicMock(stdout=""),  # missing 2
+            MagicMock(stdout="COMPLETED\n"),  # terminal
+        ]
+
+        status = manager.wait_for_job("12345678", interval=0.01, max_missing_polls=3)
+        assert status == JobStatus.COMPLETED
+        assert mock_ssh_manager.run_command.call_count == 6
+
+    def test_wait_generic_ssh_error_does_not_count_toward_budget(
+        self, mock_ssh_manager, sample_config
+    ):
+        # Only SchedulerError (no data row) is budgeted. A generic SSHError
+        # is a transport hiccup (e.g. bastion rate limiting) and is retried
+        # without bound, so repeated transport errors beyond the budget
+        # must not synthesize UNKNOWN.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = [
+            SSHError("connection reset"),
+            SSHError("connection reset"),
+            SSHError("connection reset"),
+            SSHError("connection reset"),
+            SSHError("connection reset"),
+            MagicMock(stdout="COMPLETED\n"),
+        ]
+
+        status = manager.wait_for_job("12345678", interval=0.01, max_missing_polls=3)
+        assert status == JobStatus.COMPLETED
+        assert mock_ssh_manager.run_command.call_count == 6


### PR DESCRIPTION
## Summary

`wait_for_job` caught `SchedulerError` through `except SSHError` and retried without bound, so persistently-empty status output hung the caller forever — a never-submitted job, or a PJM job aged out of every `pjstat` view. This bounds the retry and lets PJM recover a real state from the history view.

Closes #24

## Changes

- `scheduler.py`: add terminal `JobStatus.UNKNOWN`; add a `Scheduler.status_fallback_cmd` hook (base returns `None`, PJM returns the `pjstat -H` history query); extend `parse_status` to `parse_status(output, job_id=None)` — PJM uses `job_id` to accept only a row whose `jid` column matches (fail-closed), Slurm ignores it.
- `job.py`: `get_job_status` tries the fallback only on the `SchedulerError` path, best-effort — any fallback failure re-surfaces the original `SchedulerError`. `wait_for_job` gains `max_missing_polls` (default 10): consecutive `SchedulerError` polls are counted and return `JobStatus.UNKNOWN` once exhausted; the counter resets on any successful read, and generic `SSHError` stays unbounded as a transport retry.
- `cli.py`: `wait` / `submit --wait` report the unknown state explicitly and exit non-zero.

## Impact

- `get_job_status` callers (`wait_for_job`, `tail_job_output`, `get_job_output`, `hpc status`) transparently gain the PJM history fallback; an aged-out PJM job now resolves to a terminal state instead of `tail -F` spinning on a missing file.
- `parse_status` / `wait_for_job` signatures grow trailing defaulted parameters only, so existing call sites are unaffected.

## Test plan

- Budget: persistent absence returns `UNKNOWN` after the budget; the counter resets on a successful read mid-streak; generic `SSHError` is not counted.
- Fallback: PJM recovers from `-H` on empty active view; both views empty raises `SchedulerError`; a `jid`-mismatched `-H` row fails closed; a fallback command failure re-surfaces `SchedulerError` (keeps the budget in effect); Slurm makes a single call (no fallback).
- `parse_status` `job_id` guard accepts a matching row and rejects a mismatched one.
- CLI `wait` / `submit --wait` print the unknown-state line and exit non-zero.
- `uv run pytest`: 280 passed.

## Discovery contract status

The single deferred item — whether `pjstat -H --choose jid,st,ec,sn` keeps the same column layout as the active view — remains unverifiable without a PJM cluster. It is non-blocking: the job-id-validated fallback parse fails closed, so a drifted layout yields no status and degrades into the bounded budget rather than misreporting. Only the recovery *benefit* is contingent on the layout; correctness is not.

## Notes

Plan and derivations: https://github.com/ultimatile/hpc/issues/24#issuecomment-4575719180
