### PR TITLE
feat(status): render all array/het tasks in hpc status detail

### DIFF
--- a/src/hpc/cli.py
+++ b/src/hpc/cli.py
@@ -16,7 +16,7 @@ from .ssh import SSHManager
 from .sync import SyncManager
 from .job import JobManager, JobStatus
 from .run import RunManager
-from .scheduler import SchedulerError
+from .scheduler import JobDetail, SchedulerError
 
 
 class SchedulerChoice(str, Enum):
@@ -28,6 +28,19 @@ class SchedulerChoice(str, Enum):
 
     slurm = "slurm"
     pjm = "pjm"
+
+
+class DetailMode(str, Enum):
+    """CLI choices for ``hpc status --detail``.
+
+    ``summary`` (default) shows a single aggregate line for multi-task jobs;
+    ``tasks`` adds one accounting block per array task / het component. The
+    symmetric enum form leaves room for a future value (e.g. ``json``)
+    without a breaking flag rename.
+    """
+
+    summary = "summary"
+    tasks = "tasks"
 
 
 # Type alias for config option
@@ -374,8 +387,27 @@ def _normalize_sacct_state(state: str) -> str:
     return head.rstrip("+")
 
 
+def _print_detail_fields(d: JobDetail, indent: str) -> None:
+    """Print the four accounting fields, but only for terminal states where
+    they are meaningful. Non-terminal states (RUNNING / PENDING) print just
+    the state line at the call site."""
+    if _normalize_sacct_state(d.state) in _TERMINAL_SACCT_STATES:
+        print(f"{indent}ExitCode: {d.exit_code or '-'}")
+        print(f"{indent}Elapsed:  {d.elapsed or '-'}")
+        print(f"{indent}MaxRSS:   {d.max_rss or '-'}")
+        print(f"{indent}ReqMem:   {d.req_mem or '-'}")
+
+
 @app.command()
-def status(id: str = typer.Argument(None), config: ConfigOption = None):
+def status(
+    id: str = typer.Argument(None),
+    detail: DetailMode = typer.Option(
+        DetailMode.summary,
+        "--detail",
+        help="For array / het jobs: 'summary' (aggregate line) or 'tasks' (per-task blocks)",
+    ),
+    config: ConfigOption = None,
+):
     """Check job status (accepts run_id or job_id)"""
     config_path, project_root, hpc_config = _load_config(config)
 
@@ -405,13 +437,13 @@ def status(id: str = typer.Argument(None), config: ConfigOption = None):
     ssh = SSHManager(host=hpc_config.cluster.host)
     job_manager = JobManager(ssh_manager=ssh, config=hpc_config)
 
-    detail = job_manager.get_job_detail(job_id)
-    if detail is None or not detail.state:
-        # Scheduler does not support detail (PJM), or sacct has not yet
-        # recorded this job. Fall back to the existing single-line display.
-        # SchedulerError (parse-side absence) becomes a friendly message;
-        # other SSHError (real transport/command failure) propagates so
-        # legitimate failures stay visible to the user.
+    details = job_manager.get_job_detail(job_id)
+    if not details:
+        # Scheduler does not support detail (PJM -> None), or sacct has not yet
+        # recorded this job ([] -> no usable row). Fall back to the existing
+        # single-line display. SchedulerError (parse-side absence) becomes a
+        # friendly message; other SSHError (real transport/command failure)
+        # propagates so legitimate failures stay visible to the user.
         try:
             job_status = job_manager.get_job_status(job_id)
         except SchedulerError:
@@ -422,12 +454,27 @@ def status(id: str = typer.Argument(None), config: ConfigOption = None):
         print(f"Job {job_id}: {job_status.value}")
         return
 
-    print(f"Job {job_id}: {detail.state}")
-    if _normalize_sacct_state(detail.state) in _TERMINAL_SACCT_STATES:
-        print(f"  ExitCode: {detail.exit_code or '-'}")
-        print(f"  Elapsed:  {detail.elapsed or '-'}")
-        print(f"  MaxRSS:   {detail.max_rss or '-'}")
-        print(f"  ReqMem:   {detail.req_mem or '-'}")
+    if len(details) == 1:
+        # Single job: unchanged from the pre-array display.
+        d = details[0]
+        print(f"Job {job_id}: {d.state}")
+        _print_detail_fields(d, indent="  ")
+        return
+
+    # Array / het job: always surface mixed outcomes via an aggregate line so
+    # a failed task is never hidden behind the first task's state. Counts are
+    # grouped by state in first-appearance order.
+    counts: dict[str, int] = {}
+    for d in details:
+        counts[d.state] = counts.get(d.state, 0) + 1
+    unit = "components" if any("+" in d.job_id for d in details) else "tasks"
+    breakdown = ", ".join(f"{n} {state}" for state, n in counts.items())
+    print(f"Job {job_id}: {len(details)} {unit} ({breakdown})")
+
+    if detail == DetailMode.tasks:
+        for d in details:
+            print(f"  {d.job_id}: {d.state}")
+            _print_detail_fields(d, indent="    ")
 
 
 @app.command(name="list")

--- a/src/hpc/cli.py
+++ b/src/hpc/cli.py
@@ -463,10 +463,14 @@ def status(
 
     # Array / het job: always surface mixed outcomes via an aggregate line so
     # a failed task is never hidden behind the first task's state. Counts are
-    # grouped by state in first-appearance order.
+    # grouped by normalized state in first-appearance order, so Slurm
+    # decorations (`CANCELLED+`, `CANCELLED by <uid>`) collapse into one bucket
+    # instead of fragmenting the breakdown; per-task blocks below keep the raw
+    # state.
     counts: dict[str, int] = {}
     for d in details:
-        counts[d.state] = counts.get(d.state, 0) + 1
+        key = _normalize_sacct_state(d.state)
+        counts[key] = counts.get(key, 0) + 1
     unit = "components" if any("+" in d.job_id for d in details) else "tasks"
     breakdown = ", ".join(f"{n} {state}" for state, n in counts.items())
     print(f"Job {job_id}: {len(details)} {unit} ({breakdown})")

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -277,8 +277,16 @@ class JobManager:
                 # absence to keep wait_for_job's budget in effect.
                 raise primary_absence from None
 
-    def get_job_detail(self, job_id: str) -> JobDetail | None:
-        """Get detailed accounting info, or None if the scheduler does not support it."""
+    def get_job_detail(self, job_id: str) -> list[JobDetail] | None:
+        """Get detailed accounting info as one ``JobDetail`` per job / task /
+        component.
+
+        Returns ``None`` when the scheduler exposes no detail source
+        (``detail_cmd`` is ``None`` — e.g. PJM), distinct from ``[]`` which
+        means the scheduler is supported but has no usable row yet (sacct
+        accounting lag). A multi-element list represents an array job's tasks
+        or a heterogeneous job's components.
+        """
         cmd = self.scheduler.detail_cmd(job_id)
         if cmd is None:
             return None

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -54,13 +54,19 @@ class JobStatus(Enum):
 
 @dataclass
 class JobDetail:
-    """Raw scheduler-side job accounting fields.
+    """Raw scheduler-side job accounting fields for one job / task / component.
 
     Strings are stored verbatim from the scheduler so the user sees
     the exact value (e.g. ``OUT_OF_MEMORY``, ``CANCELLED+``) without
     any enum/unit normalization.
+
+    ``job_id`` is the canonical scheduler JobID of this specific row
+    (e.g. ``12345`` for a plain job, ``12345_0`` for an array task,
+    ``12345+0`` for a heterogeneous-job component) so a multi-task
+    result can be labeled and grouped per task.
     """
 
+    job_id: str
     state: str
     exit_code: str
     elapsed: str
@@ -148,9 +154,12 @@ class Scheduler(ABC):
         """Command that fetches detailed accounting info, or None if unsupported."""
         return None
 
-    def parse_detail(self, output: str) -> JobDetail | None:
-        """Parse detail-command output, or None if unsupported / unparseable."""
-        return None
+    def parse_detail(self, output: str) -> list[JobDetail]:
+        """Parse detail-command output into one ``JobDetail`` per job / task /
+        component, in scheduler order. Returns ``[]`` when the scheduler has
+        no detail support or the output has no usable row. Concrete base
+        (not abstract) so schedulers without a detail source inherit ``[]``."""
+        return []
 
 
 class Slurm(Scheduler):
@@ -236,11 +245,12 @@ class Slurm(Scheduler):
             "-P",
         ]
 
-    def parse_detail(self, output: str) -> JobDetail | None:
-        # sacct -P emits one row per accounting record (the parent step plus
-        # any sub-steps such as `.batch` / `.extern`). Columns appear in the
-        # order requested via --format. -P (parsable2) does not add a trailing
-        # '|', but we tolerate it so callers can pass -p output as well.
+    def parse_detail(self, output: str) -> list[JobDetail]:
+        # sacct -P emits one row per accounting record: a parent row per job /
+        # array task / het component (JobID without a '.') plus that row's
+        # sub-steps (`.batch`, `.extern`, `.0`, ... — always containing a '.').
+        # Columns appear in the --format order. -P (parsable2) omits the
+        # trailing '|', but we tolerate it so -p output also parses.
         rows: list[list[str]] = []
         for raw in output.splitlines():
             line = raw.strip()
@@ -253,35 +263,37 @@ class Slurm(Scheduler):
                 continue
             rows.append(fields[:6])
 
-        if not rows:
-            return None
-
-        # Parent step rows have a JobID without a '.' separator; sub-steps
-        # (`.batch`, `.extern`, `.0`, ...) always contain a dot.
-        parent = next((r for r in rows if "." not in r[0]), None)
-        if parent is None:
-            return None
-
-        # MaxRSS is per-step; the parent row typically reports an empty
-        # MaxRSS. For plain-cmd jobs the script's peak RSS lives on `.batch`,
-        # but jobs that dispatch the workload via `srun` get the real RSS
-        # on numbered step rows (`.0`, `.1`, ...) while `.batch` only
-        # reflects the launcher. Pick the maximum across all non-empty
-        # step rows so both shapes report correctly.
-        non_empty = [r[4] for r in rows if r[4]]
-        max_rss = max(non_empty, key=_max_rss_to_bytes, default="")
-
-        state = parent[1]
-        if not state:
-            return None
-
-        return JobDetail(
-            state=state,
-            exit_code=parent[2],
-            elapsed=parent[3],
-            max_rss=max_rss,
-            req_mem=parent[5],
-        )
+        # One JobDetail per parent row, in sacct order. Array tasks
+        # (`12345_0`, `12345_1`) and het components (`12345+0`, `12345+1`)
+        # each appear as their own parent row, so every task/component is
+        # represented rather than only the first.
+        details: list[JobDetail] = []
+        for parent in rows:
+            job_id = parent[0]
+            if "." in job_id:
+                continue  # sub-step row; attributed to its parent below
+            state = parent[1]
+            if not state:
+                continue  # parent not yet recorded (no usable state)
+            # MaxRSS is per-step and the parent row is usually empty; for a
+            # plain job the peak RSS lives on `.batch`, while srun-dispatched
+            # work reports it on numbered steps (`.0`, ...). Aggregate the max
+            # over this task's own rows only — the parent plus its sub-steps
+            # (`<job_id>.<step>`) — so per-task RSS never bleeds across tasks.
+            group = [parent] + [r for r in rows if r[0].startswith(job_id + ".")]
+            non_empty = [r[4] for r in group if r[4]]
+            max_rss = max(non_empty, key=_max_rss_to_bytes, default="")
+            details.append(
+                JobDetail(
+                    job_id=job_id,
+                    state=state,
+                    exit_code=parent[2],
+                    elapsed=parent[3],
+                    max_rss=max_rss,
+                    req_mem=parent[5],
+                )
+            )
+        return details
 
 
 class PJM(Scheduler):

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -275,6 +275,15 @@ class Slurm(Scheduler):
         if any("[" in r[0] for r in rows):
             return []
 
+        # Index sub-step rows by their parent JobID (everything before the
+        # first '.') so each parent's MaxRSS group is an O(1) lookup rather
+        # than an O(n) scan — keeps parse_detail linear for large arrays.
+        substeps: dict[str, list[list[str]]] = {}
+        for r in rows:
+            head, sep, _ = r[0].partition(".")
+            if sep:  # a '.' was present -> this is a sub-step row
+                substeps.setdefault(head, []).append(r)
+
         # One JobDetail per parent row, in sacct order. Array tasks
         # (`12345_0`, `12345_1`) and het components (`12345+0`, `12345+1`)
         # each appear as their own parent row, so every task/component is
@@ -292,7 +301,7 @@ class Slurm(Scheduler):
             # work reports it on numbered steps (`.0`, ...). Aggregate the max
             # over this task's own rows only — the parent plus its sub-steps
             # (`<job_id>.<step>`) — so per-task RSS never bleeds across tasks.
-            group = [parent] + [r for r in rows if r[0].startswith(job_id + ".")]
+            group = [parent] + substeps.get(job_id, [])
             non_empty = [r[4] for r in group if r[4]]
             max_rss = max(non_empty, key=_max_rss_to_bytes, default="")
             details.append(

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -272,6 +272,14 @@ class Slurm(Scheduler):
             job_id = parent[0]
             if "." in job_id:
                 continue  # sub-step row; attributed to its parent below
+            if "[" in job_id:
+                # A bracket-range JobID (e.g. `12345_[2-99]`) is sacct's
+                # compressed summary of un-launched array elements, not one
+                # real task — counting it as a single task would misreport
+                # the breakdown. Such elements have not run and carry no
+                # accounting, so they are skipped; a fully-pending array thus
+                # yields [] and falls back to the single-line status display.
+                continue
             state = parent[1]
             if not state:
                 continue  # parent not yet recorded (no usable state)

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -236,11 +236,19 @@ class Slurm(Scheduler):
         return JobStatus.COMPLETED
 
     def detail_cmd(self, job_id: str) -> list[str] | None:
+        # `-P` changes only the field separator; it does NOT disable sacct's
+        # per-field column widths, so State and JobID are still truncated to
+        # their (~10-char) defaults — `OUT_OF_MEMORY` -> `OUT_OF_ME+`, and a
+        # long array-task `JobID` -> `12345_1000.b+`. A truncated State breaks
+        # state grouping / terminal-field gating; a truncated JobID breaks the
+        # `.`-based parent/sub-step partition. Widen both (as status_cmd does
+        # for State); parsable output is not padded, so widening only raises
+        # the truncation ceiling.
         return [
             "sacct",
             "-j",
             job_id,
-            "--format=JobID,State,ExitCode,Elapsed,MaxRSS,ReqMem",
+            "--format=JobID%30,State%30,ExitCode,Elapsed,MaxRSS,ReqMem",
             "--noheader",
             "-P",
         ]

--- a/src/hpc/scheduler.py
+++ b/src/hpc/scheduler.py
@@ -263,6 +263,18 @@ class Slurm(Scheduler):
                 continue
             rows.append(fields[:6])
 
+        # A bracket-range JobID (e.g. `12345_[2-99]`) is sacct's compressed
+        # summary of un-launched array elements. Its presence means the array
+        # is only partially launched, so a per-task accounting view would be
+        # incomplete: the range can neither be counted as one task (it stands
+        # for many) nor silently dropped (that would hide pending tasks and
+        # misreport, e.g., a half-pending array as COMPLETED). Defer the whole
+        # job to the caller's aggregate-status fallback by returning no detail
+        # rows; complete per-task detail returns once every element has
+        # launched (no range row remains).
+        if any("[" in r[0] for r in rows):
+            return []
+
         # One JobDetail per parent row, in sacct order. Array tasks
         # (`12345_0`, `12345_1`) and het components (`12345+0`, `12345+1`)
         # each appear as their own parent row, so every task/component is
@@ -272,14 +284,6 @@ class Slurm(Scheduler):
             job_id = parent[0]
             if "." in job_id:
                 continue  # sub-step row; attributed to its parent below
-            if "[" in job_id:
-                # A bracket-range JobID (e.g. `12345_[2-99]`) is sacct's
-                # compressed summary of un-launched array elements, not one
-                # real task — counting it as a single task would misreport
-                # the breakdown. Such elements have not run and carry no
-                # accounting, so they are skipped; a fully-pending array thus
-                # yields [] and falls back to the single-line status display.
-                continue
             state = parent[1]
             if not state:
                 continue  # parent not yet recorded (no usable state)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -433,9 +433,30 @@ def test_status_array_job_aggregate_line_by_default(cli_runner, temp_dir, monkey
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
         instance.get_job_detail.return_value = [
-            JobDetail("12345_0", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
-            JobDetail("12345_1", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
-            JobDetail("12345_2", "OUT_OF_MEMORY", "0:125", "00:00:30", "2048K", "16Gn"),
+            JobDetail(
+                job_id="12345_0",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:00",
+                max_rss="1024K",
+                req_mem="16Gn",
+            ),
+            JobDetail(
+                job_id="12345_1",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:00",
+                max_rss="1024K",
+                req_mem="16Gn",
+            ),
+            JobDetail(
+                job_id="12345_2",
+                state="OUT_OF_MEMORY",
+                exit_code="0:125",
+                elapsed="00:00:30",
+                max_rss="2048K",
+                req_mem="16Gn",
+            ),
         ]
         result = cli_runner.invoke(app, ["status", "12345"])
 
@@ -459,8 +480,22 @@ def test_status_array_job_per_task_blocks_with_detail_tasks(
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
         instance.get_job_detail.return_value = [
-            JobDetail("12345_0", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
-            JobDetail("12345_1", "OUT_OF_MEMORY", "0:125", "00:00:30", "2048K", "16Gn"),
+            JobDetail(
+                job_id="12345_0",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:00",
+                max_rss="1024K",
+                req_mem="16Gn",
+            ),
+            JobDetail(
+                job_id="12345_1",
+                state="OUT_OF_MEMORY",
+                exit_code="0:125",
+                elapsed="00:00:30",
+                max_rss="2048K",
+                req_mem="16Gn",
+            ),
         ]
         result = cli_runner.invoke(app, ["status", "12345", "--detail", "tasks"])
 
@@ -486,9 +521,30 @@ def test_status_array_aggregate_groups_normalized_states(
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
         instance.get_job_detail.return_value = [
-            JobDetail("12345_0", "CANCELLED+", "0:15", "00:00:03", "", "8Gn"),
-            JobDetail("12345_1", "CANCELLED by 4011", "0:15", "00:00:03", "", "8Gn"),
-            JobDetail("12345_2", "COMPLETED", "0:0", "00:01:00", "1024K", "8Gn"),
+            JobDetail(
+                job_id="12345_0",
+                state="CANCELLED+",
+                exit_code="0:15",
+                elapsed="00:00:03",
+                max_rss="",
+                req_mem="8Gn",
+            ),
+            JobDetail(
+                job_id="12345_1",
+                state="CANCELLED by 4011",
+                exit_code="0:15",
+                elapsed="00:00:03",
+                max_rss="",
+                req_mem="8Gn",
+            ),
+            JobDetail(
+                job_id="12345_2",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:00",
+                max_rss="1024K",
+                req_mem="8Gn",
+            ),
         ]
         result = cli_runner.invoke(app, ["status", "12345"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,6 +473,29 @@ def test_status_array_job_per_task_blocks_with_detail_tasks(
     assert "MaxRSS:   2048K" in result.stdout
 
 
+def test_status_array_aggregate_groups_normalized_states(
+    cli_runner, temp_dir, monkeypatch
+):
+    """Decorated Slurm states (CANCELLED+ / CANCELLED by <uid>) must collapse
+    into one aggregate bucket rather than fragmenting the breakdown."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = [
+            JobDetail("12345_0", "CANCELLED+", "0:15", "00:00:03", "", "8Gn"),
+            JobDetail("12345_1", "CANCELLED by 4011", "0:15", "00:00:03", "", "8Gn"),
+            JobDetail("12345_2", "COMPLETED", "0:0", "00:01:00", "1024K", "8Gn"),
+        ]
+        result = cli_runner.invoke(app, ["status", "12345"])
+
+    assert result.exit_code == 0
+    assert "Job 12345: 3 tasks (2 CANCELLED, 1 COMPLETED)" in result.stdout
+
+
 def test_status_empty_detail_list_falls_back(cli_runner, temp_dir, monkeypatch):
     """An empty detail list (supported scheduler, no row yet) falls back to the
     single-line status display, same as the None (unsupported) case."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -306,13 +306,16 @@ def test_status_prints_sacct_fields_for_terminal_job(cli_runner, temp_dir, monke
 
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
-        instance.get_job_detail.return_value = JobDetail(
-            state="OUT_OF_MEMORY",
-            exit_code="0:125",
-            elapsed="00:01:23",
-            max_rss="1024K",
-            req_mem="16Gn",
-        )
+        instance.get_job_detail.return_value = [
+            JobDetail(
+                job_id="12345678",
+                state="OUT_OF_MEMORY",
+                exit_code="0:125",
+                elapsed="00:01:23",
+                max_rss="1024K",
+                req_mem="16Gn",
+            )
+        ]
         result = cli_runner.invoke(app, ["status", "12345678"])
 
     assert result.exit_code == 0
@@ -332,13 +335,16 @@ def test_status_omits_sacct_fields_for_running_job(cli_runner, temp_dir, monkeyp
 
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
-        instance.get_job_detail.return_value = JobDetail(
-            state="RUNNING",
-            exit_code="0:0",
-            elapsed="00:00:30",
-            max_rss="",
-            req_mem="16Gn",
-        )
+        instance.get_job_detail.return_value = [
+            JobDetail(
+                job_id="12345678",
+                state="RUNNING",
+                exit_code="0:0",
+                elapsed="00:00:30",
+                max_rss="",
+                req_mem="16Gn",
+            )
+        ]
         result = cli_runner.invoke(app, ["status", "12345678"])
 
     assert result.exit_code == 0
@@ -397,19 +403,92 @@ def test_status_normalizes_decorated_cancelled_state(cli_runner, temp_dir, monke
 
     with patch("hpc.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
-        instance.get_job_detail.return_value = JobDetail(
-            state="CANCELLED by 12345",
-            exit_code="0:15",
-            elapsed="00:00:42",
-            max_rss="",
-            req_mem="8Gn",
-        )
+        instance.get_job_detail.return_value = [
+            JobDetail(
+                job_id="12345678",
+                state="CANCELLED by 12345",
+                exit_code="0:15",
+                elapsed="00:00:42",
+                max_rss="",
+                req_mem="8Gn",
+            )
+        ]
         result = cli_runner.invoke(app, ["status", "12345678"])
 
     assert result.exit_code == 0
     assert "Job 12345678: CANCELLED by 12345" in result.stdout
     assert "ExitCode: 0:15" in result.stdout
     assert "MaxRSS:   -" in result.stdout
+
+
+def test_status_array_job_aggregate_line_by_default(cli_runner, temp_dir, monkeypatch):
+    """Issue #16: a multi-task array surfaces mixed outcomes via an aggregate
+    line by default, never collapsing to the first task's state. No per-task
+    accounting fields without --detail tasks."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = [
+            JobDetail("12345_0", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
+            JobDetail("12345_1", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
+            JobDetail("12345_2", "OUT_OF_MEMORY", "0:125", "00:00:30", "2048K", "16Gn"),
+        ]
+        result = cli_runner.invoke(app, ["status", "12345"])
+
+    assert result.exit_code == 0
+    assert "Job 12345: 3 tasks (2 COMPLETED, 1 OUT_OF_MEMORY)" in result.stdout
+    # No per-task drill-down in the default (summary) mode.
+    assert "12345_2:" not in result.stdout
+    assert "ExitCode" not in result.stdout
+
+
+def test_status_array_job_per_task_blocks_with_detail_tasks(
+    cli_runner, temp_dir, monkeypatch
+):
+    """--detail tasks adds one accounting block per task, labeled by the
+    canonical JobID, with terminal fields shown per task."""
+    from hpc.scheduler import JobDetail
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = [
+            JobDetail("12345_0", "COMPLETED", "0:0", "00:01:00", "1024K", "16Gn"),
+            JobDetail("12345_1", "OUT_OF_MEMORY", "0:125", "00:00:30", "2048K", "16Gn"),
+        ]
+        result = cli_runner.invoke(app, ["status", "12345", "--detail", "tasks"])
+
+    assert result.exit_code == 0
+    assert "Job 12345: 2 tasks (1 COMPLETED, 1 OUT_OF_MEMORY)" in result.stdout
+    assert "12345_0: COMPLETED" in result.stdout
+    assert "12345_1: OUT_OF_MEMORY" in result.stdout
+    # Per-task accounting for each terminal task.
+    assert "MaxRSS:   1024K" in result.stdout
+    assert "MaxRSS:   2048K" in result.stdout
+
+
+def test_status_empty_detail_list_falls_back(cli_runner, temp_dir, monkeypatch):
+    """An empty detail list (supported scheduler, no row yet) falls back to the
+    single-line status display, same as the None (unsupported) case."""
+    from hpc.job import JobStatus
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("hpc.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = []
+        instance.get_job_status.return_value = JobStatus.PENDING
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert "Job 12345678: PENDING" in result.stdout
 
 
 def test_wait_reports_unknown_state_and_exits_nonzero(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -399,14 +399,17 @@ class TestJobManagerDetail:
             )
         )
 
-        detail = manager.get_job_detail("12345")
-        assert detail == JobDetail(
-            state="COMPLETED",
-            exit_code="0:0",
-            elapsed="00:01:23",
-            max_rss="1024K",
-            req_mem="16Gn",
-        )
+        details = manager.get_job_detail("12345")
+        assert details == [
+            JobDetail(
+                job_id="12345",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:23",
+                max_rss="1024K",
+                req_mem="16Gn",
+            )
+        ]
         call_args = mock_ssh_manager.run_command.call_args
         assert call_args.args[0] == "sacct"
         assert "-P" in call_args.args[1]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -341,23 +341,26 @@ class TestSlurmParseDetail:
             "12345.batch|COMPLETED|0:0|00:01:23|1024K|16Gn\n"
             "12345.extern|COMPLETED|0:0|00:01:23|0|16Gn\n"
         )
-        detail = Slurm().parse_detail(output)
-        assert detail == JobDetail(
-            state="COMPLETED",
-            exit_code="0:0",
-            elapsed="00:01:23",
-            max_rss="1024K",
-            req_mem="16Gn",
-        )
+        details = Slurm().parse_detail(output)
+        assert details == [
+            JobDetail(
+                job_id="12345",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:23",
+                max_rss="1024K",
+                req_mem="16Gn",
+            )
+        ]
 
     def test_parse_picks_step_max_rss_when_no_batch_row(self):
         output = (
             "12345|COMPLETED|0:0|00:00:42||8Gn\n"
             "12345.0|COMPLETED|0:0|00:00:42|512K|8Gn\n"
         )
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.max_rss == "512K"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].max_rss == "512K"
 
     def test_parse_picks_largest_max_rss_across_srun_steps(self):
         # MPI / GPU jobs that dispatch via `srun` put the real workload RSS
@@ -368,9 +371,9 @@ class TestSlurmParseDetail:
             "12345.0|COMPLETED|0:0|01:23:45|2500M|64Gn\n"
             "12345.extern|COMPLETED|0:0|01:23:45|0|64Gn\n"
         )
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.max_rss == "2500M"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].max_rss == "2500M"
 
     def test_parse_compares_max_rss_unit_aware(self):
         # 1G must beat 999M even though "1G" sorts before "999M" lexically.
@@ -379,56 +382,102 @@ class TestSlurmParseDetail:
             "12345.batch|COMPLETED|0:0|00:10:00|999M|16Gn\n"
             "12345.0|COMPLETED|0:0|00:10:00|1G|16Gn\n"
         )
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.max_rss == "1G"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].max_rss == "1G"
 
     def test_parse_tolerates_trailing_pipe_from_parsable_mode(self):
         output = "12345|COMPLETED|0:0|00:00:10||4Gn|\n12345.batch|COMPLETED|0:0|00:00:10|256K|4Gn|\n"
-        detail = Slurm().parse_detail(output)
-        assert detail == JobDetail(
-            state="COMPLETED",
-            exit_code="0:0",
-            elapsed="00:00:10",
-            max_rss="256K",
-            req_mem="4Gn",
-        )
+        details = Slurm().parse_detail(output)
+        assert details == [
+            JobDetail(
+                job_id="12345",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:00:10",
+                max_rss="256K",
+                req_mem="4Gn",
+            )
+        ]
 
     def test_parse_preserves_raw_oom_state(self):
         output = "12345|OUT_OF_MEMORY|0:125|00:00:05||4Gn\n"
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.state == "OUT_OF_MEMORY"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].state == "OUT_OF_MEMORY"
 
     def test_parse_preserves_decorated_cancelled_state(self):
         output = "12345|CANCELLED+|0:0|00:00:03||4Gn\n"
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.state == "CANCELLED+"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].state == "CANCELLED+"
 
-    def test_parse_empty_output_returns_none(self):
-        assert Slurm().parse_detail("") is None
-        assert Slurm().parse_detail("\n\n") is None
+    def test_parse_empty_output_returns_empty_list(self):
+        assert Slurm().parse_detail("") == []
+        assert Slurm().parse_detail("\n\n") == []
 
-    def test_parse_no_parent_row_returns_none(self):
-        # Only step rows present, no parent row -> cannot identify primary state.
+    def test_parse_no_parent_row_returns_empty_list(self):
+        # Only step rows present, no parent row -> nothing to attribute.
         output = "12345.batch|COMPLETED|0:0|00:00:05|256K|4Gn\n"
-        assert Slurm().parse_detail(output) is None
+        assert Slurm().parse_detail(output) == []
 
     def test_parse_skips_short_rows(self):
-        # A malformed row (too few fields) is dropped, parent row still wins.
+        # A malformed row (too few fields) is dropped; the parent row remains.
         output = "broken\n12345|COMPLETED|0:0|00:00:05||4Gn\n"
-        detail = Slurm().parse_detail(output)
-        assert detail is not None
-        assert detail.state == "COMPLETED"
+        details = Slurm().parse_detail(output)
+        assert len(details) == 1
+        assert details[0].job_id == "12345"
+        assert details[0].state == "COMPLETED"
+
+    def test_parse_array_job_returns_per_task_details(self):
+        # Issue #16: each array task is its own parent row. All tasks must be
+        # represented (not just the first), and each task's MaxRSS must come
+        # from its own substep rows — no cross-task bleed.
+        output = (
+            "12345_0|COMPLETED|0:0|00:01:00||16Gn\n"
+            "12345_0.batch|COMPLETED|0:0|00:01:00|1024K|16Gn\n"
+            "12345_1|OUT_OF_MEMORY|0:125|00:00:30||16Gn\n"
+            "12345_1.batch|OUT_OF_MEMORY|0:125|00:00:30|2048K|16Gn\n"
+        )
+        details = Slurm().parse_detail(output)
+        assert details == [
+            JobDetail(
+                job_id="12345_0",
+                state="COMPLETED",
+                exit_code="0:0",
+                elapsed="00:01:00",
+                max_rss="1024K",
+                req_mem="16Gn",
+            ),
+            JobDetail(
+                job_id="12345_1",
+                state="OUT_OF_MEMORY",
+                exit_code="0:125",
+                elapsed="00:00:30",
+                max_rss="2048K",
+                req_mem="16Gn",
+            ),
+        ]
+
+    def test_parse_het_job_returns_per_component_details(self):
+        output = (
+            "12345+0|COMPLETED|0:0|00:01:00||16Gn\n"
+            "12345+0.batch|COMPLETED|0:0|00:01:00|512K|16Gn\n"
+            "12345+1|FAILED|1:0|00:00:10||8Gn\n"
+            "12345+1.batch|FAILED|1:0|00:00:10|256K|8Gn\n"
+        )
+        details = Slurm().parse_detail(output)
+        assert [d.job_id for d in details] == ["12345+0", "12345+1"]
+        assert [d.state for d in details] == ["COMPLETED", "FAILED"]
+        assert [d.max_rss for d in details] == ["512K", "256K"]
 
 
 class TestPJMDetailNotSupported:
     def test_pjm_detail_cmd_returns_none(self):
         assert PJM().detail_cmd("12345") is None
 
-    def test_pjm_parse_detail_returns_none(self):
-        assert PJM().parse_detail("anything") is None
+    def test_pjm_parse_detail_returns_empty_list(self):
+        assert PJM().parse_detail("anything") == []
 
 
 class TestSlurmOutput:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -459,24 +459,24 @@ class TestSlurmParseDetail:
             ),
         ]
 
-    def test_parse_skips_bracket_range_summary_row(self):
+    def test_parse_partially_pending_array_defers_to_fallback(self):
         # sacct compresses un-launched array elements into a bracket-range
-        # JobID (`12345_[2-9]`). It is a summary of many pending tasks, not a
-        # single task, so it must not be counted as one — only the launched
-        # tasks (which carry accounting) are returned.
+        # JobID (`12345_[2-9]`). While such a row is present the array is only
+        # partially launched, so a per-task view is incomplete. parse_detail
+        # returns [] for the whole job so the CLI shows the aggregate status
+        # instead of misreporting (e.g. a half-pending array as COMPLETED).
         output = (
             "12345_0|COMPLETED|0:0|00:01:00||16Gn\n"
             "12345_0.batch|COMPLETED|0:0|00:01:00|1024K|16Gn\n"
             "12345_1|RUNNING|0:0|00:00:30||16Gn\n"
             "12345_[2-9]|PENDING|0:0|00:00:00||16Gn\n"
         )
-        details = Slurm().parse_detail(output)
-        assert [d.job_id for d in details] == ["12345_0", "12345_1"]
+        assert Slurm().parse_detail(output) == []
 
     def test_parse_fully_pending_array_returns_empty_list(self):
         # An array with no launched tasks yet shows only the bracket-range
-        # row; with that skipped, parse_detail returns [] so the CLI falls
-        # back to the single-line status display.
+        # row, so parse_detail returns [] and the CLI falls back to the
+        # single-line status display.
         output = "12345_[0-9]|PENDING|0:0|00:00:00||16Gn\n"
         assert Slurm().parse_detail(output) == []
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -459,6 +459,27 @@ class TestSlurmParseDetail:
             ),
         ]
 
+    def test_parse_skips_bracket_range_summary_row(self):
+        # sacct compresses un-launched array elements into a bracket-range
+        # JobID (`12345_[2-9]`). It is a summary of many pending tasks, not a
+        # single task, so it must not be counted as one — only the launched
+        # tasks (which carry accounting) are returned.
+        output = (
+            "12345_0|COMPLETED|0:0|00:01:00||16Gn\n"
+            "12345_0.batch|COMPLETED|0:0|00:01:00|1024K|16Gn\n"
+            "12345_1|RUNNING|0:0|00:00:30||16Gn\n"
+            "12345_[2-9]|PENDING|0:0|00:00:00||16Gn\n"
+        )
+        details = Slurm().parse_detail(output)
+        assert [d.job_id for d in details] == ["12345_0", "12345_1"]
+
+    def test_parse_fully_pending_array_returns_empty_list(self):
+        # An array with no launched tasks yet shows only the bracket-range
+        # row; with that skipped, parse_detail returns [] so the CLI falls
+        # back to the single-line status display.
+        output = "12345_[0-9]|PENDING|0:0|00:00:00||16Gn\n"
+        assert Slurm().parse_detail(output) == []
+
     def test_parse_het_job_returns_per_component_details(self):
         output = (
             "12345+0|COMPLETED|0:0|00:01:00||16Gn\n"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -328,7 +328,9 @@ class TestSlurmDetailCmd:
         assert cmd is not None
         assert cmd[0] == "sacct"
         assert "12345" in cmd
-        assert "--format=JobID,State,ExitCode,Elapsed,MaxRSS,ReqMem" in cmd
+        # State and JobID are widened so sacct does not truncate long values
+        # (OUT_OF_MEMORY, long array-task JobIDs) under -P.
+        assert "--format=JobID%30,State%30,ExitCode,Elapsed,MaxRSS,ReqMem" in cmd
         assert "--noheader" in cmd
         assert "-P" in cmd
 


### PR DESCRIPTION
## Summary

`hpc status` on a Slurm array or heterogeneous job reported the accounting of the **first** task only, so a mixed-outcome array showed `COMPLETED` even when another task was `OUT_OF_MEMORY`. The polling path (#10) already aggregates across tasks; this brings the detail path (#5) to parity.

Closes #16

## Changes

- `scheduler.py`: `JobDetail` gains a leading `job_id` field (canonical sacct JobID, e.g. `12345_0` / `12345+0`). `Scheduler.parse_detail` now returns `list[JobDetail]` (concrete base returns `[]`). `Slurm.parse_detail` emits one entry per parent row, aggregating `MaxRSS` only within each task's own substep rows so per-task memory never bleeds across tasks.
- `job.py`: `get_job_detail` returns `list[JobDetail] | None` — `None` when the scheduler has no detail source (PJM), `[]` when supported but no usable row.
- `cli.py`: `status` gains a symmetric `--detail {summary,tasks}` option (default `summary`, mirroring `--scheduler`). Single-task jobs render unchanged; multi-task jobs show an aggregate line (`Job 12345: 3 tasks (2 COMPLETED, 1 OUT_OF_MEMORY)`), and `--detail tasks` adds one accounting block per task / component.

## Impact

- `get_job_detail` / `parse_detail` have a single consumer, `cli.status`, rewritten for the list. The polling / `wait_for_job` path is untouched.
- `parse_detail` / `get_job_detail` return-type changes and the new `JobDetail.job_id` field are covered at every construction / call site (src + tests).

## Test plan

- `parse_detail`: array (per-task `job_id` / `state` / no-RSS-bleed), het components, single job, empty / header-only / no-parent → `[]`.
- partially- and fully-pending arrays (a bracket-range row present) → `[]` so the CLI defers to the aggregate status.
- `get_job_detail`: Slurm → list, PJM → `None`.
- `status`: single-task unchanged (regression pin), multi-task aggregate (default), `--detail tasks` per-task blocks, empty-list / PJM fallback.
- `uv run pytest`: 288 passed.

## Discovery contract status

The plan deferred the exact handling of sacct's compressed bracket-range rows (`12345_[2-99]`, emitted while array elements are still un-launched). Review surfaced that neither counting such a row as one task nor silently dropping it is correct, so it was **resolved in this PR** rather than left deferred: when any bracket-range row is present, `parse_detail` returns `[]` and the CLI shows the aggregate status (`PENDING` / `RUNNING`); complete per-task detail returns once every element has launched.

Runtime confirmation of sacct's array / het JobID column shapes on a live Slurm cluster remains deferred (no Slurm cluster is available); the row taxonomy is standard, documented behavior already relied on by the existing `.`-based substep filter.

## Notes

The aggregate line uses ASCII parentheses (`3 tasks (2 COMPLETED, ...)`) rather than the em-dash shown illustratively in the plan, keeping CLI stdout ASCII-only and consistent with the rest of the output.

Plan and derivations: https://github.com/ultimatile/hpc/issues/16#issuecomment-4581336322
