### PR TITLE
fix(config): prevent shell injection from config-derived values

### DIFF
--- a/src/hpc/config.py
+++ b/src/hpc/config.py
@@ -1,5 +1,6 @@
 """Configuration management"""
 
+import re
 import shlex
 import sys
 import tomllib
@@ -20,10 +21,46 @@ def _validate_arg(arg: str) -> None:
         raise ValueError(f"Shell special characters not allowed: {bad}")
 
 
+# Values rendered into a double-quoted shell context — ``export KEY="<value>"``
+# in the job script and ``cd "<job_workdir>"`` — must still permit remote
+# parameter expansion (``${USER}``, ``${SLURM_CPUS_PER_TASK}``) yet admit no
+# path to command execution. Inside double quotes the only execution vectors
+# are command substitution (``$(`` / backtick), arithmetic expansion (``$((``),
+# prompt re-expansion (``${x@P}``), and indirect expansion (``${!x}``); bash
+# does NOT re-scan the result of a parameter expansion, so a value that merely
+# contains ``$(...)`` as text stays inert without an ``@P`` trigger. A literal
+# ``"`` or backslash would close or escape out of the quotes.
+#
+# A blocklist of ``$(`` / backtick is therefore insufficient: ``${x@P}`` can
+# re-evaluate a payload assembled from other allowed values containing none of
+# the blocked substrings. Instead, strip the only forms we want (simple
+# ``$VAR`` / ``${VAR}`` references) and reject any residual ``$`` (rejected
+# conservatively: a leftover ``$`` may begin a dangerous ``$``-form, and a
+# bare literal ``$`` — inert but unneeded here — is not worth distinguishing),
+# backtick, ``"``, backslash, newline, or NUL.
+_SAFE_VAR_REF = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*")
+_DQ_FORBIDDEN = set('$`"\\\n\x00')
+
+
+def _validate_dq_shell_value(value: str, label: str = "value") -> None:
+    """Reject a double-quoted-context value that could execute a command.
+
+    See the module comment above for why a whitelist (strip simple variable
+    references, then forbid residual shell-active characters) is required
+    rather than a blocklist of ``$(`` / backtick.
+    """
+    residual = _SAFE_VAR_REF.sub("", value)
+    if bad := _DQ_FORBIDDEN & set(residual):
+        raise ValueError(
+            f"Unsafe characters in {label} (rendered in a double-quoted shell "
+            f"context): {''.join(sorted(bad))!r} in {value!r}"
+        )
+
+
 def _validate_export_value(value: str) -> None:
-    """Reject command substitution in export values while allowing variable references."""
-    if "$(" in value or "`" in value:
-        raise ValueError(f"Command substitution not allowed in export value: {value!r}")
+    """Reject export values that could execute a command while still allowing
+    simple variable references such as ``${SLURM_CPUS_PER_TASK}``."""
+    _validate_dq_shell_value(value, label="export value")
 
 
 def build_setup_commands(setup: list[SetupItem]) -> list[str]:
@@ -93,13 +130,20 @@ class SyncConfig(BaseModel):
     pull_dir: str = ""
 
 
+def _reject_directive_control_chars(value: str, label: str) -> None:
+    """Reject newline / NUL — the only characters that break a scheduler
+    directive (``#SBATCH`` / ``#PJM``) comment line into an executable
+    script line. In-line shell metacharacters are inert on a ``#``-comment
+    line, so unlike a double-quoted value (see ``_validate_dq_shell_value``)
+    nothing else needs rejecting here."""
+    if "\n" in value or "\x00" in value:
+        raise ValueError(f"Newline and NUL characters are not allowed in {label}")
+
+
 def _validate_submit_options(opts: list[str]) -> list[str]:
     """Reject only structurally unsafe characters in submit options."""
     for opt in opts:
-        if "\n" in opt or "\x00" in opt:
-            raise ValueError(
-                "Newline and NUL characters are not allowed in submit_options"
-            )
+        _reject_directive_control_chars(opt, "submit_options")
     return opts
 
 
@@ -114,6 +158,21 @@ class SlurmConfig(BaseModel):
     def check_submit_options(cls, v: list[str]) -> list[str]:
         return _validate_submit_options(v)
 
+    @field_validator("options")
+    @classmethod
+    def check_options(cls, v: dict[str, str | int]) -> dict[str, str | int]:
+        # ``options`` render into the job-script directive lines
+        # (``#SBATCH --key=value``); a newline injects an executable script
+        # line, exactly the hazard ``submit_options`` already guards against
+        # (those are passed as submit-command argv, but share the same ban on
+        # structural control chars). Both the key and a string value reach the
+        # rendered line; an int value cannot carry control characters.
+        for key, value in v.items():
+            _reject_directive_control_chars(key, "slurm.options keys")
+            if isinstance(value, str):
+                _reject_directive_control_chars(value, "slurm.options values")
+        return v
+
 
 class PjmConfig(BaseModel):
     """PJM job configuration"""
@@ -125,6 +184,18 @@ class PjmConfig(BaseModel):
     @classmethod
     def check_submit_options(cls, v: list[str]) -> list[str]:
         return _validate_submit_options(v)
+
+    @field_validator("options")
+    @classmethod
+    def check_options(cls, v: list[list[str]]) -> list[list[str]]:
+        # Every inner-list element can reach a ``#PJM`` directive line; reject
+        # the newline / NUL that would terminate the comment line. The renderer
+        # currently emits only ``opt[0]`` / ``opt[1]``, but validating every
+        # element matches ``submit_options``' policy and is conservative.
+        for opt in v:
+            for element in opt:
+                _reject_directive_control_chars(element, "pjm.options elements")
+        return v
 
 
 class HpcConfig(BaseModel):

--- a/src/hpc/job.py
+++ b/src/hpc/job.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from jinja2 import Template
 
-from .config import HpcConfig
+from .config import HpcConfig, _validate_dq_shell_value
 from .ssh import SSHManager
 from .run import RunConfig
 from .scheduler import JobDetail, JobStatus, SchedulerError, get_scheduler
@@ -34,7 +34,7 @@ JOB_TEMPLATE = """#!/bin/bash
 {{ directive }}
 {% endfor %}
 
-cd {{ job_workdir }}
+cd "{{ job_workdir }}"
 
 {% for cmd in setup_commands %}
 {{ cmd }}
@@ -153,6 +153,13 @@ class JobManager:
         template = Template(JOB_TEMPLATE)
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
         job_workdir = str(Path(workdir) / cwd_relative)
+        # job_workdir is rendered into `cd "<job_workdir>"` and undergoes remote
+        # ${USER}-style expansion. It combines three attacker-influenceable
+        # sources — cluster.workdir, the --workdir CLI override, and the local
+        # cwd_relative path — so validate the final combined string here. A
+        # ClusterConfig field validator alone would miss the override (assigned
+        # directly onto the model) and the cwd_relative component.
+        _validate_dq_shell_value(job_workdir, label="job workdir")
         run_dir = f"{workdir}/.hpc/runs/{run.run_id}"
         options = (
             self.config.pjm.options
@@ -203,6 +210,10 @@ class JobManager:
         """
         template = Template(JOB_TEMPLATE)
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
+        # Validated for the same reason as in _render_job_script: workdir is
+        # rendered into `cd "<workdir>"`. This legacy path has no cwd_relative
+        # component, so the resolved workdir is the full job working directory.
+        _validate_dq_shell_value(workdir, label="job workdir")
         run_dir = f"{workdir}/.hpc/runs/job"
         options = (
             self.config.pjm.options

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,47 @@ from hpc.config import (
     HpcConfig,
     ConfigManager,
     find_config,
+    _validate_dq_shell_value,
 )
+
+
+class TestDqShellValueValidator:
+    """The shared validator guarding double-quoted shell contexts
+    (`export KEY="..."`, `cd "..."`)."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            'a"; touch /tmp/pwned; echo "',  # quote breakout
+            "$(touch /tmp/pwned)",  # command substitution
+            "`touch /tmp/pwned`",  # backtick substitution
+            "${BAR@P}",  # prompt re-expansion bypass
+            "${!BAR}",  # indirect expansion
+            "${BAR:-$(x)}",  # default-value form smuggling $(
+            "$((1 + 1))",  # arithmetic expansion
+            "a\nb",  # newline
+            "a\x00b",  # NUL
+            "a\\b",  # backslash escape
+        ],
+    )
+    def test_rejects_unsafe(self, value):
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            _validate_dq_shell_value(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "$HOME",
+            "${USER}",
+            "${SLURM_CPUS_PER_TASK}",
+            "/scratch/${USER}/proj",
+            "/scratch/user/proj",
+            "02:00:00",
+            "plain",
+        ],
+    )
+    def test_allows_safe(self, value):
+        _validate_dq_shell_value(value)  # must not raise
 
 
 class TestClusterConfig:
@@ -53,13 +93,49 @@ class TestEnvConfig:
 
     def test_exports_rejects_command_substitution_dollar(self):
         config = EnvConfig(exports={"FOO": "$(rm -rf /)"})
-        with pytest.raises(ValueError, match="Command substitution"):
+        with pytest.raises(ValueError, match="Unsafe characters"):
             config.get_setup_commands()
 
     def test_exports_rejects_command_substitution_backtick(self):
         config = EnvConfig(exports={"FOO": "`rm -rf /`"})
-        with pytest.raises(ValueError, match="Command substitution"):
+        with pytest.raises(ValueError, match="Unsafe characters"):
             config.get_setup_commands()
+
+    def test_exports_rejects_double_quote_breakout(self):
+        # The value is rendered inside `export KEY="<value>"`; a literal `"`
+        # closes the quote and turns the rest into commands. The pre-whitelist
+        # validator (which blocked only `$(` / backtick) let this through.
+        config = EnvConfig(exports={"FOO": 'x"; touch /tmp/pwned; echo "'})
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_exports_rejects_prompt_expansion(self):
+        # `${VAR@P}` re-evaluates its value as a prompt string, performing
+        # command substitution assembled from otherwise-allowed values — a
+        # bypass no blocklist of `$(` / backtick can catch.
+        config = EnvConfig(exports={"FOO": "${BAR@P}"})
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_exports_rejects_newline(self):
+        config = EnvConfig(exports={"FOO": "a\nb"})
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_exports_rejects_nul(self):
+        config = EnvConfig(exports={"FOO": "a\x00b"})
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_exports_allows_simple_variable_references(self):
+        # Simple `$VAR` / `${VAR}` parameter references must survive — they are
+        # the intended remote-expansion use case.
+        config = EnvConfig(
+            exports={"HOME_REF": "$HOME", "NESTED": "/scratch/${USER}/out"}
+        )
+        cmds = config.get_setup_commands()
+        assert 'export HOME_REF="$HOME"' in cmds
+        assert 'export NESTED="/scratch/${USER}/out"' in cmds
 
     def test_exports_rejects_invalid_key(self):
         config = EnvConfig(exports={"FOO;BAR": "value"})
@@ -92,6 +168,25 @@ class TestSlurmConfig:
         with pytest.raises(ValueError, match="Newline and NUL"):
             SlurmConfig(submit_options=["--opt\x00malicious"])
 
+    def test_slurm_config_rejects_newline_in_option_value(self):
+        # options render into `#SBATCH --key=value` directive lines; a newline
+        # in the value injects an executable script line.
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            SlurmConfig(options={"partition": "gpu\ntouch /tmp/pwned"})
+
+    def test_slurm_config_rejects_newline_in_option_key(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            SlurmConfig(options={"part\nition": "gpu"})
+
+    def test_slurm_config_rejects_nul_in_option_value(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            SlurmConfig(options={"partition": "gpu\x00x"})
+
+    def test_slurm_config_allows_int_option_value(self):
+        # int values cannot carry control chars; the validator must skip them.
+        config = SlurmConfig(options={"nodes": 1, "time": "02:00:00"})
+        assert config.options["nodes"] == 1
+
 
 class TestPjmConfig:
     def test_pjm_config_defaults(self):
@@ -106,6 +201,19 @@ class TestPjmConfig:
     def test_pjm_config_rejects_newline_in_submit_options(self):
         with pytest.raises(ValueError, match="Newline and NUL"):
             PjmConfig(submit_options=["--opt\nmalicious"])
+
+    def test_pjm_config_rejects_newline_in_option_element(self):
+        # Each inner-list element can reach a `#PJM` directive line.
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            PjmConfig(options=[["-L", "node=1\ntouch /tmp/pwned"]])
+
+    def test_pjm_config_rejects_nul_in_option_element(self):
+        with pytest.raises(ValueError, match="Newline and NUL"):
+            PjmConfig(options=[["-L", "node=1\x00x"]])
+
+    def test_pjm_config_allows_normal_options(self):
+        config = PjmConfig(options=[["-L", "node=1"], ["-g", "myaccount"]])
+        assert config.options[0] == ["-L", "node=1"]
 
 
 class TestHpcConfig:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -450,7 +450,7 @@ class TestJobManagerTemplate:
 
         run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
         script = manager._render_job_script(run)
-        assert "cd /scratch/user/proj" in script
+        assert 'cd "/scratch/user/proj"' in script
 
     def test_render_job_script_with_subdirectory(self, mock_ssh_manager, sample_config):
         """cwd_relative appends subdirectory to workdir for job cd"""
@@ -459,9 +459,34 @@ class TestJobManagerTemplate:
 
         run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
         script = manager._render_job_script(run, cwd_relative=Path("runs/bench1"))
-        assert "cd /scratch/user/proj/runs/bench1" in script
+        assert 'cd "/scratch/user/proj/runs/bench1"' in script
         # Output paths still use base workdir
         assert "--output=/scratch/user/proj/.hpc/runs/test_run" in script
+
+    def test_render_job_script_quotes_workdir(self, mock_ssh_manager, sample_config):
+        """The `cd` line is double-quoted so `;` / whitespace in a workdir stay
+        inert while `${USER}`-style expansion is preserved."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
+        script = manager._render_job_script(run)
+        assert 'cd "' in script
+        assert "cd /scratch" not in script  # never the bare, unquoted form
+
+    def test_render_job_script_rejects_cwd_relative_breakout(
+        self, mock_ssh_manager, sample_config
+    ):
+        """A maliciously-named local subdir must not escape the quoted `cd`;
+        the render choke point validates the combined job_workdir."""
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        from hpc.run import RunConfig
+
+        run = RunConfig(run_id="test_run", cmd="echo hi", status="pending")
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            manager._render_job_script(
+                run, cwd_relative=Path('a"; touch /tmp/pwned; echo "b')
+            )
 
     def test_render_job_script_pjm_emits_pjm_output_directives(self, mock_ssh_manager):
         """PJM jobs must emit ``#PJM -o`` / ``#PJM -e`` for the bookkeeping
@@ -791,7 +816,7 @@ class TestJobManagerHoistsUserDirectives:
 
         # User directive lands in the prologue, before `cd`.
         array_idx = script.index("#SBATCH --array=1-10%5")
-        cd_idx = script.index("cd /scratch/user/proj")
+        cd_idx = script.index('cd "/scratch/user/proj"')
         assert array_idx < cd_idx
         # And before the template's hardcoded --output= bookkeeping line, so
         # hpc's run-tracking output path always wins over any user override.
@@ -817,7 +842,7 @@ class TestJobManagerHoistsUserDirectives:
         run = RunConfig(run_id="test_run", cmd=cmd, status="pending")
         script = manager._render_job_script(run)
 
-        cd_idx = script.index("cd /scratch/user/proj")
+        cd_idx = script.index('cd "/scratch/user/proj"')
         for directive in ('#PJM -L "rscgrp=small"', "#PJM -j", "#PJM -N myjob"):
             assert directive in script
             assert script.index(directive) < cd_idx
@@ -888,6 +913,6 @@ class TestJobManagerHoistsUserDirectives:
         # The rendered script is piped to sbatch via input_text.
         call_args = mock_ssh_manager.run_command.call_args
         script = call_args.kwargs["input_text"]
-        cd_idx = script.index("cd /scratch/user/proj")
+        cd_idx = script.index('cd "/scratch/user/proj"')
         assert script.index("#SBATCH --array=1-5") < cd_idx
         assert script.count("#!/bin/bash") == 1


### PR DESCRIPTION
## Summary

Three config-derived strings reached the remotely-executed job script without adequate validation, so a poisoned config (or, for one vector, a maliciously-named local directory) could inject commands that run on the cluster under the user's account via `hpc submit`. Two of the three are gaps relative to validation the code already intends: `env.exports` and `*.submit_options` had validators that were either incomplete or not mirrored onto sibling fields.

This matters once the tool is installed by users who run it inside repositories whose config they did not author — `find_config` walks up from the CWD and silently adopts the nearest one.

## Changes

- `src/hpc/config.py`: add `_validate_dq_shell_value`, a shared validator for values rendered into a double-quoted shell context (`export KEY="..."`, `cd "..."`). It strips simple `$VAR` / `${VAR}` references and rejects any residual `$`, backtick, `"`, backslash, newline, or NUL — a whitelist, because a blocklist of `$(` / backtick is bypassable (see the export-value case below).
- **Export values** — `_validate_export_value` previously rejected only `$(` and backtick, but the value is rendered inside double quotes, so a `"` closed the quote and `${VAR@P}` prompt expansion re-evaluated a payload assembled from other allowed values. Rewritten to use the shared validator.
- **Scheduler options** — `slurm.options` / `pjm.options` render into `#SBATCH` / `#PJM` directive lines but, unlike `submit_options`, were not newline/NUL- validated; a newline terminates the comment line and starts an executable one. Added a `field_validator` to each (keys + string values for Slurm, every inner-list element for PJM).
- **Job working directory** — `job_workdir` was rendered unquoted into `cd`. Quoted it (`cd "{{ job_workdir }}"`, which keeps `${USER}` expansion while neutralizing `;` / whitespace) and validated the final combined string — config workdir, the `--workdir` override, and the local CWD offset — at the render choke point in `_render_job_script` and `submit_job`.

## Impact

`_validate_export_value` keeps its signature; only its body changed. All new symbols are internal helpers. Valid configurations render identically — `${USER}` / `${SLURM_CPUS_PER_TASK}` expansion is preserved. The job-script `cd` line is now double-quoted, so render tests asserting the bare form were updated to the quoted form.

## Test plan

- Export values: reject quote breakout, `${VAR@P}`, `$(`, backtick, indirect / default-value / arithmetic forms, newline, NUL, backslash; accept `$HOME`, `${USER}`, `${SLURM_CPUS_PER_TASK}`, and plain values.
- Scheduler options: reject newline / NUL in a Slurm option value, a Slurm option key, and a PJM option element; the int-value path is skipped; normal options still load.
- Job working directory: the shared validator rejects unsafe workdirs and accepts `${USER}` paths; the rendered script emits the workdir quoted; a breakout via the local CWD component is rejected at the render choke point.
- `pytest`: 320 passed. `ruff check` / `ruff format --check`: clean.

## Out of scope

These related hardening items are not addressed here and could each be a separate follow-up: the ambient-config trust surface (`find_config` adopting an ancestor config without confirmation), the predictable `/tmp` SSH control path, rsync pull writing remote-controlled files locally, run metadata flowing into directive lines, and the `env.setup` "config is trusted code" assumption.
