### PR TITLE
docs: add "Why not Snakemake?" positioning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hpc
 
-An automation CLI tool for HPC workflow: source code/data sync and scheduler job management (Slurm/PJM).
+One-stop lightweight wrapper for seamless remote-HPC dev-loop for coding agents and humans: sync the working tree, run a quick verification job (Slurm/PJM), pull results.
 
 ## Why not Snakemake?
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 An automation CLI tool for HPC workflow: source code/data sync and scheduler job management (Slurm/PJM).
 
+## Why not Snakemake?
+
+hpc is **not** a job orchestrator, and does not try to be one.
+
+Its responsibility is the inner development loop against a remote environment: you are actively editing code — often *before it is committed* — and you want to push the current working tree to a remote HPC environment and run a quick test there, repeatedly and fast. [Snakemake](https://github.com/snakemake/snakemake), [Nextflow](https://github.com/nextflow-io/nextflow), and similar tools assume a defined, committed pipeline and manage its execution graph; they serve the *other* end of the lifecycle.
+
+They are complementary, not competing:
+
+- **hpc** — frequent pre-commit source sync, single test / verification runs, a tight edit → run → observe loop. Built for a coding agent iterating against a remote environment.
+- **A workflow runner** — dependency graphs, multi-step pipelines, retries, production runs.
+
+If you need to orchestrate a complex production run, use a real orchestrator — and you can still launch it *through* hpc (`hpc submit "snakemake ..."`): hpc handles the transport (sync up, run, pull results) and treats the workflow as opaque user code. hpc owns the transport and the dev loop, never the run graph.
+
 ## Installation
 
 One-shot execution (no install):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hpc
 
-One-stop lightweight wrapper for seamless remote-HPC dev-loop for coding agents and humans: sync the working tree, run a quick verification job (Slurm/PJM), pull results.
+A CLI that makes a remote HPC cluster feel local — sync your working tree, run a quick job (Slurm/PJM), pull results.
 
 ## Why not Snakemake?
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A CLI that makes a remote HPC cluster feel local — sync your working tree, run
 
 hpc is **not** a job orchestrator, and does not try to be one.
 
-Its responsibility is the inner development loop against a remote environment: you are actively editing code — often *before it is committed* — and you want to push the current working tree to a remote HPC environment and run a quick test there, repeatedly and fast. [Snakemake](https://github.com/snakemake/snakemake), [Nextflow](https://github.com/nextflow-io/nextflow), and similar tools assume a defined, committed pipeline and manage its execution graph; they serve the *other* end of the lifecycle.
+Its responsibility is the inner development loop against a remote environment: you are actively editing code — often *before it is committed* — and you want to push the current working tree to a remote HPC environment and run a quick test there, repeatedly and quickly. [Snakemake](https://github.com/snakemake/snakemake), [Nextflow](https://github.com/nextflow-io/nextflow), and similar tools assume a defined, committed pipeline and manage its execution graph; they serve the *other* end of the lifecycle.
 
 They are complementary, not competing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "hpc"
 version = "0.6.0"
-description = "an automation CLI tool for HPC workflow."
+description = "One-stop lightweight wrapper giving coding agents and humans a seamless remote-HPC dev loop: sync, run a quick job (Slurm/PJM), pull results."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "hpc"
 version = "0.6.0"
-description = "One-stop lightweight wrapper giving coding agents and humans a seamless remote-HPC dev loop: sync, run a quick job (Slurm/PJM), pull results."
+description = "A CLI that makes a remote HPC cluster feel local — sync your working tree, run a quick job (Slurm/PJM), pull results."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Tighten the README's positioning so hpc reads as what it is — an inner-dev-loop tool for a remote HPC environment — rather than orchestration tooling.

- Rewrite the one-line description (README tagline + `pyproject.toml` `description`, which surfaces on PyPI): lead with the lightweight remote-HPC dev loop (sync the working tree, run a quick verification job, pull results) instead of the orchestration-flavored "scheduler job management".
- Add a prominent `## Why not Snakemake?` section: hpc serves frequent pre-commit source sync and quick verification runs and is deliberately *not* a job orchestrator. For dependency graphs, multi-step pipelines, retries, or production runs, delegate to a workflow runner (Snakemake / Nextflow / …), which can still be launched through hpc (`hpc submit "snakemake ..."`); hpc owns the transport and the dev loop, never the run graph.

## Notes

Docs / metadata only — no code or behavior change.
