### PR TITLE
feat!: unify env config into a single ordered setup list

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,12 @@ workdir = "/scratch/user/proj"    # Remote working directory; all codes and data
 scheduler = "slurm"                # "slurm" (default) or "pjm"
 
 [env]
-modules = ["gcc/12.2.0", "cuda/12.2"]  # Modules to load (shorthand for module load)
-spack = ["python@3.11"]                # Spack packages to load (shorthand for spack load)
-setup = [                              # Additional setup commands
-    {source = "/path/to/venv/bin/activate"},
-    {export = ["VAR=value"]},          # {command = [args...]} format
-    "some_cmd",                        # String: command without args
+# A single ordered list. Commands run in list order.
+setup = [
+    {module = "gcc/12.2.0"},                  # → module load gcc/12.2.0
+    {spack = "python@3.11"},                  # → spack load python@3.11
+    {source = ["/path/to/venv/bin/activate"]},
+    {export = {VAR = "value"}},               # → export VAR="value"
 ]
 
 [sync]
@@ -234,31 +234,47 @@ gpus = 1               # Example (Slurm): number of GPUs
 
 ### Environment Setup
 
-Commands are executed in this order: `modules` → `spack` → `setup`.
+`setup` is a single ordered list of items. Each item is a one-key table
+`{command = args}`, and items run in the order they are written — `setup` is the
+one place execution order is declared.
 
-`modules` and `spack` are shorthand syntax:
+Item kinds:
 
-- `modules = ["gcc/12.2.0"]` expands to `module load gcc/12.2.0`
-- `spack = ["python@3.11"]` expands to `spack load python@3.11`
+- `{module = "gcc/12.2.0"}` → `module load gcc/12.2.0`
+- `{spack = "python@3.11"}` → `spack load python@3.11`
+- `{export = {KEY = "val"}}` → `export KEY="val"`
+- `{command = [args...]}` → `command args...` — generic escape hatch for any
+  single command, e.g. `{ulimit = ["-s", "unlimited"]}` → `ulimit -s unlimited`.
+  A no-argument command is written `{command = []}`.
 
-`setup` accepts:
+Because a Spack spec is a single unit that contains spaces (version + variants +
+arch), `module` and `spack` accept spaces in the spec:
 
-- String: command without args (e.g., `"some_cmd"`)
-- Dict: `{command = args}` format (e.g., `{export = ["VAR=value"]}` → `export VAR=value`)
-- Special commands `module` and `spack` in dict format expand to `module load` / `spack load`
+```toml
+{spack = "boost@1.86.0 ~mpi arch=linux-rhel8-a64fx"}
+```
 
-If you need a different execution order, put everything in `setup`:
+To enable Spack itself before loading, source its setup script first — order is
+under your control:
 
 ```toml
 [env]
 setup = [
-    {spack = "python@3.11"},
-    {module = "gcc/12.2.0"},
-    {source = "/path/to/venv/bin/activate"},
+    {source = ["/opt/spack/share/spack/setup-env.sh"]},
+    {spack = "boost@1.86.0 ~mpi arch=linux-rhel8-a64fx"},
 ]
 ```
 
-Shell special characters (`` ;|&`$<>\'"\n `` and space) are prohibited in arguments for security.
+Shell special characters (`` ;|&`$<>\'"\n ``) are prohibited in arguments for
+security. Arguments to `module`, `spack`, and generic commands are shell-quoted
+before they reach the job script (a space is allowed only inside a `module` /
+`spack` spec, as above). An `export` value is instead rendered into a
+double-quoted context and validated for it, so `${VAR}` references are kept while
+command substitution (`$(...)`, backticks, `${VAR@P}`) is rejected.
+
+There is intentionally no bare-string or inline raw-command form: an
+unvalidated command is arbitrary code execution. Put arbitrary shell logic in a
+remote script and invoke it with `{source = ["script.sh"]}`.
 
 ### PJM Configuration
 

--- a/README.md
+++ b/README.md
@@ -234,18 +234,19 @@ gpus = 1               # Example (Slurm): number of GPUs
 
 ### Environment Setup
 
-`setup` is a single ordered list of items. Each item is a one-key table
-`{command = args}`, and items run in the order they are written — `setup` is the
-one place execution order is declared.
+`setup` is a single ordered list of items. Each item is a one-key table whose
+key is the command name, and items run in the order they are written — `setup`
+is the one place execution order is declared.
 
 Item kinds:
 
 - `{module = "gcc/12.2.0"}` → `module load gcc/12.2.0`
 - `{spack = "python@3.11"}` → `spack load python@3.11`
 - `{export = {KEY = "val"}}` → `export KEY="val"`
-- `{command = [args...]}` → `command args...` — generic escape hatch for any
-  single command, e.g. `{ulimit = ["-s", "unlimited"]}` → `ulimit -s unlimited`.
-  A no-argument command is written `{command = []}`.
+- Any other key is a generic command rendered as `<key> <args...>`, e.g.
+  `{ulimit = ["-s", "unlimited"]}` → `ulimit -s unlimited`, or
+  `{source = ["/path/to/venv/bin/activate"]}` → `source /path/to/venv/bin/activate`.
+  Pass arguments as a list; a no-argument command is `{mycmd = []}`.
 
 Because a Spack spec is a single unit that contains spaces (version + variants +
 arch), `module` and `spack` accept spaces in the spec:

--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -129,7 +129,7 @@ def _apply_xdg_with_filter(src: Path, dst: Path, scheduler: SchedulerChoice) -> 
     active value. The source file itself is not modified.
 
     The destination inherits the source's permission bits so a restrictive
-    XDG mode (e.g. ``0o600`` for a file carrying ``env.exports`` secrets) is
+    XDG mode (e.g. ``0o600`` for a file carrying ``env`` export secrets) is
     not silently relaxed to the umask default — the previous ``shutil.copy``
     path preserved mode bits, and the rewrite must too.
     """

--- a/src/crewster/config.py
+++ b/src/crewster/config.py
@@ -8,16 +8,26 @@ from pathlib import Path
 from typing import Literal
 
 import tomli_w
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
-# str: command without args, dict: {cmd: args}
-SetupItem = str | dict[str, str | list[str]]
+# A setup item is a single-key table ``{command: args}``. ``args`` is a string
+# or list of arguments, except for ``export`` whose args is a ``{KEY: value}``
+# table. Bare strings are intentionally excluded: a raw, unvalidated command is
+# arbitrary code execution, so arbitrary shell logic must go through a remote
+# script invoked via ``{source = ["script.sh"]}`` instead.
+SetupItem = dict[str, str | list[str] | dict[str, str]]
 
 SHELL_SPECIAL = set(";|&`$<>\\'\"\n ")
 
 
-def _validate_arg(arg: str) -> None:
-    if bad := SHELL_SPECIAL & set(arg):
+def _validate_arg(arg: str, *, allow_space: bool = False) -> None:
+    # ``allow_space`` is set for ``module`` / ``spack`` specs: a spec is one
+    # logical unit that legitimately contains spaces (``boost@1.0 ~mpi
+    # arch=...``), and each token is ``shlex.quote``d before reaching the
+    # script, so the space cannot break out of its argument. The genuinely
+    # dangerous metacharacters stay banned regardless.
+    forbidden = SHELL_SPECIAL - {" "} if allow_space else SHELL_SPECIAL
+    if bad := forbidden & set(arg):
         raise ValueError(f"Shell special characters not allowed: {bad}")
 
 
@@ -64,27 +74,61 @@ def _validate_export_value(value: str) -> None:
 
 
 def build_setup_commands(setup: list[SetupItem]) -> list[str]:
-    """Build shell commands from setup items"""
+    """Build shell commands from an ordered list of setup items.
+
+    Each item is a single-key table ``{command: args}`` rendered in list order,
+    so the config author controls execution order directly. Item kinds:
+
+    - ``{export = {KEY = "val"}}`` → ``export KEY="val"`` (rendered in a
+      double-quoted context and validated with ``_validate_export_value``).
+    - ``{module = ...}`` / ``{spack = ...}`` → ``module load`` / ``spack load``.
+    - ``{<cmd> = [args...]}`` → ``<cmd> <args...>`` — the safe escape hatch.
+      Every token is metacharacter-validated and ``shlex.quote``d, so no shell
+      control operator can originate from config.
+
+    A table value is accepted only for ``export``; for any other command it is a
+    configuration error rather than a silently mishandled item.
+    """
     cmds = []
     for item in setup:
-        if isinstance(item, str):
-            _validate_arg(item)
-            cmds.append(shlex.quote(item))
-        else:
-            cmd, args = next(iter(item.items()))
-            _validate_arg(cmd)
-            args_list = [args] if isinstance(args, str) else args
-            args_list = [a for a in args_list if a]
-            for a in args_list:
-                _validate_arg(a)
+        # A multi-key table would silently drop all but the first command; make
+        # it an explicit error instead of guessing the author's intent.
+        if len(item) != 1:
+            raise ValueError(
+                f"Each setup item must have exactly one command key: {item!r}"
+            )
+        cmd, args = next(iter(item.items()))
+        _validate_arg(cmd)
+        if cmd == "export":
+            if not isinstance(args, dict):
+                raise ValueError(
+                    f"'export' requires a table of KEY = value pairs: {args!r}"
+                )
+            for key, value in args.items():
+                _validate_arg(key)
+                _validate_export_value(value)
+                cmds.append(f'export {key}="{value}"')
+            continue
+        if isinstance(args, dict):
+            raise ValueError(
+                f"A table value is only allowed for 'export', not {cmd!r}: {args!r}"
+            )
+        allow_space = cmd in {"module", "spack"}
+        args_list = [args] if isinstance(args, str) else args
+        args_list = [a for a in args_list if a]
+        for a in args_list:
+            _validate_arg(a, allow_space=allow_space)
+        if cmd in {"module", "spack"}:
+            # ``module load`` / ``spack load`` need an operand; an empty spec
+            # would emit a bare ``load`` that errors on the remote, so reject it
+            # rather than ship a malformed command.
+            if not args_list:
+                raise ValueError(f"{cmd!r} requires a spec: {args!r}")
             quoted_args = " ".join(shlex.quote(a) for a in args_list)
-            if cmd == "module":
-                cmds.append(f"module load {quoted_args}")
-            elif cmd == "spack":
-                cmds.append(f"spack load {quoted_args}")
-            else:
-                parts = [shlex.quote(cmd)] + [shlex.quote(a) for a in args_list]
-                cmds.append(" ".join(parts))
+            cmds.append(f"{cmd} load {quoted_args}")
+        else:
+            parts = [shlex.quote(cmd)] + [shlex.quote(a) for a in args_list]
+            cmds.append(" ".join(parts))
     return cmds
 
 
@@ -97,27 +141,22 @@ class ClusterConfig(BaseModel):
 
 
 class EnvConfig(BaseModel):
-    """Environment configuration"""
+    """Environment configuration.
 
-    modules: list[str] = []
-    spack: list[str] = []
+    Environment setup is a single ordered ``setup`` list; commands render in
+    list order, which is the one place execution order is declared.
+    ``extra="forbid"`` makes a removed bucket key (the former ``modules`` /
+    ``spack`` / ``exports`` fields) fail loudly rather than be silently dropped
+    — a silent drop would leave the environment unconfigured.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     setup: list[SetupItem] = []
-    exports: dict[str, str] = {}
 
     def get_setup_commands(self) -> list[str]:
-        """Build commands: modules → spack → setup → exports"""
-        items: list[SetupItem] = []
-        for m in self.modules:
-            items.append({"module": m})
-        for s in self.spack:
-            items.append({"spack": s})
-        items.extend(self.setup)
-        cmds = build_setup_commands(items)
-        for key, value in self.exports.items():
-            _validate_arg(key)
-            _validate_export_value(value)
-            cmds.append(f'export {key}="{value}"')
-        return cmds
+        """Render the ordered setup list to shell commands."""
+        return build_setup_commands(self.setup)
 
 
 class SyncConfig(BaseModel):
@@ -288,7 +327,9 @@ class ConfigManager:
                     "scheduler": "pjm",
                 },
                 "env": {
-                    "modules": ["gcc/12.2.0"],
+                    "setup": [
+                        {"module": "gcc/12.2.0"},
+                    ],
                 },
                 "sync": {
                     "ignore": ["crewster.toml", ".git"],
@@ -312,7 +353,10 @@ class ConfigManager:
                     "scheduler": "slurm",
                 },
                 "env": {
-                    "modules": ["gcc/12.2.0", "cuda/12.2"],
+                    "setup": [
+                        {"module": "gcc/12.2.0"},
+                        {"module": "cuda/12.2"},
+                    ],
                 },
                 "sync": {
                     "ignore": ["crewster.toml", ".git"],

--- a/src/crewster/config.py
+++ b/src/crewster/config.py
@@ -125,8 +125,21 @@ def build_setup_commands(setup: list[SetupItem]) -> list[str]:
                 f"A table value is only allowed for 'export', not {cmd!r}: {args!r}"
             )
         allow_space = cmd in {"module", "spack"}
-        args_list = [args] if isinstance(args, str) else args
-        args_list = [a for a in args_list if a]
+        # A bare string is the single-spec form for module / spack only; a
+        # generic command takes an explicit argument list so token boundaries
+        # are unambiguous (``"-s unlimited"`` would otherwise be one arg).
+        if isinstance(args, str):
+            if not allow_space:
+                raise ValueError(
+                    f"{cmd!r} requires a list of arguments, not a string: {args!r}"
+                )
+            args_list = [args]
+        else:
+            args_list = args
+        # Reject empty tokens rather than silently dropping them, so a typo like
+        # ``["", "boost"]`` fails loudly instead of rendering a partial command.
+        if any(not a for a in args_list):
+            raise ValueError(f"{cmd!r} has an empty argument: {args!r}")
         for a in args_list:
             _validate_arg(a, allow_space=allow_space)
         if cmd in {"module", "spack"}:

--- a/src/crewster/config.py
+++ b/src/crewster/config.py
@@ -73,6 +73,17 @@ def _validate_export_value(value: str) -> None:
     _validate_dq_shell_value(value, label="export value")
 
 
+# POSIX environment variable name. A name that is not a valid shell identifier
+# (``123FOO``, ``FOO-BAR``) would emit an ``export`` the remote shell rejects;
+# reject it at config time so the failure is loud and local.
+_ENV_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+
+def _validate_export_key(key: str) -> None:
+    if not _ENV_NAME.match(key):
+        raise ValueError(f"Invalid environment variable name: {key!r}")
+
+
 def build_setup_commands(setup: list[SetupItem]) -> list[str]:
     """Build shell commands from an ordered list of setup items.
 
@@ -105,7 +116,7 @@ def build_setup_commands(setup: list[SetupItem]) -> list[str]:
                     f"'export' requires a table of KEY = value pairs: {args!r}"
                 )
             for key, value in args.items():
-                _validate_arg(key)
+                _validate_export_key(key)
                 _validate_export_value(value)
                 cmds.append(f'export {key}="{value}"')
             continue

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,9 +205,12 @@ class TestEnvConfig:
         with pytest.raises(ValueError, match="Unsafe characters"):
             config.get_setup_commands()
 
-    def test_export_rejects_invalid_key(self):
-        config = EnvConfig(setup=[{"export": {"FOO;BAR": "value"}}])
-        with pytest.raises(ValueError):
+    @pytest.mark.parametrize("key", ["FOO;BAR", "123FOO", "FOO-BAR", "FOO BAR", ""])
+    def test_export_rejects_invalid_key(self, key):
+        # An export name that is not a valid shell identifier would emit an
+        # `export` the remote shell rejects, so reject it at config time.
+        config = EnvConfig(setup=[{"export": {key: "value"}}])
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
             config.get_setup_commands()
 
     # --- clean-break rejections ---------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,17 +129,32 @@ class TestEnvConfig:
         config = EnvConfig(setup=[{"nvidia-smi": []}])
         assert config.get_setup_commands() == ["nvidia-smi"]
 
-    @pytest.mark.parametrize("spec", ["", []])
-    def test_module_requires_spec(self, spec):
-        # An empty spec would emit a bare `module load` that errors remotely.
-        config = EnvConfig(setup=[{"module": spec}])
+    @pytest.mark.parametrize("cmd", ["module", "spack"])
+    def test_module_spack_empty_list_requires_spec(self, cmd):
+        # An empty list would emit a bare `load` that errors remotely.
+        config = EnvConfig(setup=[{cmd: []}])
         with pytest.raises(ValueError, match="requires a spec"):
             config.get_setup_commands()
 
-    @pytest.mark.parametrize("spec", ["", []])
-    def test_spack_requires_spec(self, spec):
-        config = EnvConfig(setup=[{"spack": spec}])
-        with pytest.raises(ValueError, match="requires a spec"):
+    @pytest.mark.parametrize("cmd", ["module", "spack"])
+    @pytest.mark.parametrize("spec", ["", ["", "boost@1.86.0"]])
+    def test_module_spack_reject_empty_token(self, cmd, spec):
+        # An empty token is rejected rather than silently dropped, so it cannot
+        # render a partial command.
+        config = EnvConfig(setup=[{cmd: spec}])
+        with pytest.raises(ValueError, match="empty argument"):
+            config.get_setup_commands()
+
+    def test_generic_command_requires_list_not_string(self):
+        # A bare string is the single-spec form for module / spack only; a
+        # generic command must pass an explicit argument list.
+        config = EnvConfig(setup=[{"source": "/path/setup-env.sh"}])
+        with pytest.raises(ValueError, match="requires a list of arguments"):
+            config.get_setup_commands()
+
+    def test_generic_command_rejects_empty_token(self):
+        config = EnvConfig(setup=[{"ulimit": ["-s", ""]}])
+        with pytest.raises(ValueError, match="empty argument"):
             config.get_setup_commands()
 
     def test_generic_command_rejects_metacharacters(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pathlib import Path
+from pydantic import ValidationError
 
 from crewster.config import (
     ClusterConfig,
@@ -70,76 +71,171 @@ class TestEnvConfig:
         config = EnvConfig(setup=[{"module": "gcc/12.2.0"}, {"spack": "cuda@12"}])
         assert len(config.setup) == 2
 
-    def test_env_config_with_string_command(self):
-        config = EnvConfig(setup=["my_setup"])
-        assert config.setup == ["my_setup"]
-
     def test_env_config_defaults(self):
         config = EnvConfig()
         assert config.setup == []
 
-    def test_env_config_rejects_shell_special(self):
-        config = EnvConfig(setup=[{"module": "gcc; rm -rf ~"}])
-        with pytest.raises(Exception):
+    def test_module_and_spack_render_load_commands(self):
+        config = EnvConfig(setup=[{"module": "gcc/12.2.0"}, {"spack": "cuda@12"}])
+        assert config.get_setup_commands() == [
+            "module load gcc/12.2.0",
+            "spack load cuda@12",
+        ]
+
+    def test_setup_preserves_list_order(self):
+        # The single ordered list is the one place execution order is declared;
+        # commands must render in exactly the authored order.
+        config = EnvConfig(
+            setup=[
+                {"export": {"SPACK_ROOT": "/opt/spack"}},
+                {"source": ["/opt/spack/share/spack/setup-env.sh"]},
+                {"spack": "boost@1.86.0"},
+                {"module": "gcc/12.2.0"},
+            ]
+        )
+        assert config.get_setup_commands() == [
+            'export SPACK_ROOT="/opt/spack"',
+            "source /opt/spack/share/spack/setup-env.sh",
+            "spack load boost@1.86.0",
+            "module load gcc/12.2.0",
+        ]
+
+    def test_spack_spec_allows_spaces(self):
+        # A spack spec is one logical unit that legitimately contains spaces
+        # (version + variant + arch). It renders to a single quoted shell word,
+        # which spack parses back into one spec.
+        config = EnvConfig(
+            setup=[{"spack": "boost@1.86.0 ~mpi arch=linux-rhel8-a64fx"}]
+        )
+        assert config.get_setup_commands() == [
+            "spack load 'boost@1.86.0 ~mpi arch=linux-rhel8-a64fx'"
+        ]
+
+    def test_module_spec_allows_spaces(self):
+        config = EnvConfig(setup=[{"module": "gcc 12.2.0"}])
+        assert config.get_setup_commands() == ["module load 'gcc 12.2.0'"]
+
+    def test_spack_still_rejects_dangerous_metacharacters(self):
+        # The space relaxation must not relax the genuinely dangerous chars.
+        config = EnvConfig(setup=[{"spack": "boost; rm -rf ~"}])
+        with pytest.raises(ValueError, match="Shell special characters"):
             config.get_setup_commands()
 
-    def test_exports_generates_export_commands(self):
+    def test_generic_command_is_safe_escape_hatch(self):
+        config = EnvConfig(setup=[{"ulimit": ["-s", "unlimited"]}])
+        assert config.get_setup_commands() == ["ulimit -s unlimited"]
+
+    def test_generic_command_no_args(self):
+        config = EnvConfig(setup=[{"nvidia-smi": []}])
+        assert config.get_setup_commands() == ["nvidia-smi"]
+
+    @pytest.mark.parametrize("spec", ["", []])
+    def test_module_requires_spec(self, spec):
+        # An empty spec would emit a bare `module load` that errors remotely.
+        config = EnvConfig(setup=[{"module": spec}])
+        with pytest.raises(ValueError, match="requires a spec"):
+            config.get_setup_commands()
+
+    @pytest.mark.parametrize("spec", ["", []])
+    def test_spack_requires_spec(self, spec):
+        config = EnvConfig(setup=[{"spack": spec}])
+        with pytest.raises(ValueError, match="requires a spec"):
+            config.get_setup_commands()
+
+    def test_generic_command_rejects_metacharacters(self):
+        # The escape hatch quotes each token, but still bans control operators
+        # so a shell metacharacter can never originate from config.
+        config = EnvConfig(setup=[{"ulimit": ["-s; rm -rf ~"]}])
+        with pytest.raises(ValueError, match="Shell special characters"):
+            config.get_setup_commands()
+
+    # --- export item ---------------------------------------------------------
+
+    def test_export_item_generates_export_commands(self):
         config = EnvConfig(
-            exports={"OMP_NUM_THREADS": "${SLURM_CPUS_PER_TASK}", "FOO": "bar"}
+            setup=[
+                {"export": {"OMP_NUM_THREADS": "${SLURM_CPUS_PER_TASK}", "FOO": "bar"}}
+            ]
         )
         cmds = config.get_setup_commands()
         assert 'export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK}"' in cmds
         assert 'export FOO="bar"' in cmds
 
-    def test_exports_rejects_command_substitution_dollar(self):
-        config = EnvConfig(exports={"FOO": "$(rm -rf /)"})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_rejects_command_substitution_backtick(self):
-        config = EnvConfig(exports={"FOO": "`rm -rf /`"})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_rejects_double_quote_breakout(self):
-        # The value is rendered inside `export KEY="<value>"`; a literal `"`
-        # closes the quote and turns the rest into commands. The pre-whitelist
-        # validator (which blocked only `$(` / backtick) let this through.
-        config = EnvConfig(exports={"FOO": 'x"; touch /tmp/pwned; echo "'})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_rejects_prompt_expansion(self):
-        # `${VAR@P}` re-evaluates its value as a prompt string, performing
-        # command substitution assembled from otherwise-allowed values — a
-        # bypass no blocklist of `$(` / backtick can catch.
-        config = EnvConfig(exports={"FOO": "${BAR@P}"})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_rejects_newline(self):
-        config = EnvConfig(exports={"FOO": "a\nb"})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_rejects_nul(self):
-        config = EnvConfig(exports={"FOO": "a\x00b"})
-        with pytest.raises(ValueError, match="Unsafe characters"):
-            config.get_setup_commands()
-
-    def test_exports_allows_simple_variable_references(self):
+    def test_export_allows_simple_variable_references(self):
         # Simple `$VAR` / `${VAR}` parameter references must survive — they are
         # the intended remote-expansion use case.
         config = EnvConfig(
-            exports={"HOME_REF": "$HOME", "NESTED": "/scratch/${USER}/out"}
+            setup=[{"export": {"HOME_REF": "$HOME", "NESTED": "/scratch/${USER}/out"}}]
         )
         cmds = config.get_setup_commands()
         assert 'export HOME_REF="$HOME"' in cmds
         assert 'export NESTED="/scratch/${USER}/out"' in cmds
 
-    def test_exports_rejects_invalid_key(self):
-        config = EnvConfig(exports={"FOO;BAR": "value"})
+    def test_export_rejects_command_substitution_dollar(self):
+        config = EnvConfig(setup=[{"export": {"FOO": "$(rm -rf /)"}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_command_substitution_backtick(self):
+        config = EnvConfig(setup=[{"export": {"FOO": "`rm -rf /`"}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_double_quote_breakout(self):
+        # The value is rendered inside `export KEY="<value>"`; a literal `"`
+        # closes the quote and turns the rest into commands.
+        config = EnvConfig(setup=[{"export": {"FOO": 'x"; touch /tmp/pwned; echo "'}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_prompt_expansion(self):
+        # `${VAR@P}` re-evaluates its value as a prompt string, performing
+        # command substitution assembled from otherwise-allowed values.
+        config = EnvConfig(setup=[{"export": {"FOO": "${BAR@P}"}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_newline(self):
+        config = EnvConfig(setup=[{"export": {"FOO": "a\nb"}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_nul(self):
+        config = EnvConfig(setup=[{"export": {"FOO": "a\x00b"}}])
+        with pytest.raises(ValueError, match="Unsafe characters"):
+            config.get_setup_commands()
+
+    def test_export_rejects_invalid_key(self):
+        config = EnvConfig(setup=[{"export": {"FOO;BAR": "value"}}])
         with pytest.raises(ValueError):
+            config.get_setup_commands()
+
+    # --- clean-break rejections ---------------------------------------------
+
+    @pytest.mark.parametrize("field", ["modules", "spack", "exports"])
+    def test_old_bucket_keys_rejected(self, field):
+        # The removed top-level buckets must fail loudly (extra="forbid"),
+        # not be silently dropped into an empty environment.
+        with pytest.raises(ValidationError):
+            EnvConfig(**{field: ["gcc/12.2.0"]})
+
+    def test_bare_string_item_rejected(self):
+        with pytest.raises(ValidationError):
+            EnvConfig(setup=["my_setup"])
+
+    def test_multi_key_item_rejected(self):
+        config = EnvConfig(setup=[{"module": "gcc", "spack": "cuda"}])
+        with pytest.raises(ValueError, match="exactly one command key"):
+            config.get_setup_commands()
+
+    def test_table_value_rejected_for_non_export(self):
+        config = EnvConfig(setup=[{"module": {"foo": "bar"}}])
+        with pytest.raises(ValueError, match="only allowed for 'export'"):
+            config.get_setup_commands()
+
+    def test_export_requires_table_value(self):
+        config = EnvConfig(setup=[{"export": ["FOO=bar"]}])
+        with pytest.raises(ValueError, match="requires a table"):
             config.get_setup_commands()
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -20,7 +20,7 @@ def mock_ssh_manager():
 def sample_config():
     return HpcConfig(
         cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
-        env=EnvConfig(modules=["gcc/12.2.0"]),
+        env=EnvConfig(setup=[{"module": "gcc/12.2.0"}]),
         slurm=SlurmConfig(
             options={"partition": "gpu", "time": "02:00:00", "mem": "32G", "gpus": 1}
         ),

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -13,7 +13,7 @@ from crewster.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig
 def sample_config():
     return HpcConfig(
         cluster=ClusterConfig(host="myhpc", workdir="/scratch/user/proj"),
-        env=EnvConfig(modules=["gcc/12.2.0"]),
+        env=EnvConfig(setup=[{"module": "gcc/12.2.0"}]),
         slurm=SlurmConfig(partition="gpu", time="02:00:00", mem="32G", gpus=1),
     )
 


### PR DESCRIPTION
## Summary

Environment setup in `[env]` was split across four typed buckets (`modules`, `spack`, `setup`, `exports`) concatenated in a fixed order (`modules → spack → setup → exports`), which cannot express real cross-bucket dependencies — most notably sourcing spack's `setup-env.sh` before `spack load`, since spack is not on `PATH` after login under its standard deployment model.

This collapses the four buckets into a single ordered `setup` list of typed items. List order is execution order, so the author controls ordering directly, and a spack spec (one logical unit that contains spaces) can finally be written as-is.

Closes #38

## Changes

- `src/crewster/config.py`:
  - `SetupItem` drops the bare-string form; items are one-key tables.
  - `build_setup_commands` renders a single ordered list: `{export={KEY="val"}}`, `{module=...}` / `{spack=...}` (specs may contain spaces), and `{cmd=[args...]}` as a safe escape hatch (every token shell-quoted); `{source=[...]}` is just an instance of that generic form. Multi-key items, a table value for a non-`export` command, an `export` without a table, and an empty `module` / `spack` spec are all rejected.
  - `_validate_arg` gains a keyword-only `allow_space` (set for `module` / `spack` specs); shell metacharacters (`` ;|&`$<>'"\n ``) otherwise stay banned, and `export` values keep the existing double-quoted-context validation (allows `${VAR}` references, rejects command substitution, `${VAR@P}`, and quote breakout).
  - `EnvConfig` keeps only `setup` and sets `extra="forbid"` so a removed bucket key fails loudly instead of being silently dropped.
  - `generate_template` emits the `setup` form.
- `src/crewster/cli.py`: docstring reference to `env.exports` updated.
- `README.md`: `[env]` example and Environment Setup section rewritten.

## Impact

`EnvConfig`'s field set changed, but every consumer goes through `get_setup_commands()` (`src/crewster/cli.py`, `src/crewster/job.py`), whose signature is unchanged. No code reads the removed fields. `_validate_arg`'s new parameter is keyword-only with a `False` default, so existing positional calls are unaffected.

This is a breaking config-schema change: `[env]` no longer accepts `modules` / `spack` / `exports` or bare-string setup items. They move into the list as `{module=...}` / `{spack=...}` / `{export={...}}`.

## Test plan

- Order preservation, space-in-spec rendering, the `export` item (carrying over the export-value validation cases), the generic escape hatch and its metacharacter rejection, empty-spec rejection, and the clean-break rejections (old bucket keys, bare strings, multi-key items, wrong-typed values).
- Template round-trip (slurm + pjm) verified to load back and render.
- `pytest`: 348 passed. `ruff check`: clean.

## Notes

The implementation plan is in #38. An inline raw `{raw=...}` form is intentionally not added: an unvalidated command is arbitrary code execution, so arbitrary shell logic goes in a remote script invoked via `{source=[...]}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Environment setup now uses a single ordered `setup` list (replacing `modules`, `spack`, and `exports`).
  * Each `setup` entry must be a one-key table, e.g. `{module}`, `{spack}`, `{source}`, `{export}`, `{command}`.
  * `export` requires `{KEY: value}`; `module`/`spack` specs can be a string or list of tokens; commands require an explicit argument list.

* **Documentation**
  * Updated the environment-setup guide with the new ordered schema and stricter shell-safety/quoting and `export` validation.

* **Tests**
  * Updated fixtures and assertions to reflect the `setup`-based model and new rendering/validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->