### PR TITLE
feat: add --project-dir to override the config-derived project root

### DIFF
--- a/.claude/skills/crewster/SKILL.md
+++ b/.claude/skills/crewster/SKILL.md
@@ -29,12 +29,12 @@ If `crewster.toml` does not exist in the project, run `crewster init` to create 
 
 ## Key Concepts
 
-- **Project root**: crewster walks up from CWD to find `crewster.toml` (like git finds `.git`). All commands work from any subdirectory.
+- **Project root**: crewster walks up from CWD to find `crewster.toml` (like git finds `.git`). All commands work from any subdirectory. `--project-dir <path>` overrides the derived project root (for configs kept outside the working tree); it requires an explicit config (`--config` or `$CREWSTER_CONFIG`), and metadata-reading commands (`status`, `list`, `job-output`, `wait`) must be re-invoked with the same `--project-dir` the run was submitted with.
 - **run_id vs job_id**: `crewster submit` returns both. Either can be used with `status`, `job-output`, `wait`.
 - **Default working directory**: `crewster submit` runs the job with its PWD set to the resolved `[cluster].workdir` from `crewster.toml`. Scripts passed via `-s` therefore do **not** need to `cd` to the project root — they start there. Adding a manual `cd` (or relying on `$SLURM_SUBMIT_DIR`, which may not be propagated to the job's environment) can move the job to the wrong directory.
 - **Multi-setup runs**: Submit from subdirectories to set the job's remote working directory accordingly (e.g., `cd runs/setup-a && crewster submit "python main.py"` runs in `/remote/project/runs/setup-a`).
 - **Config resolution**: `--config` / `-c` > `$CREWSTER_CONFIG` > walk-up discovery > `./crewster.toml`. A legacy `$HPC_CONFIG` / `hpc.toml` is still read as a deprecated fallback (prints a warning; removed in v1.0).
-- **Sync scope**: `crewster sync` always syncs the entire project root, regardless of CWD.
+- **Sync scope**: `crewster sync` always syncs the entire project root (the `--project-dir` override when given), regardless of CWD.
 
 ## Writing scripts for `crewster submit -s`
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When `$XDG_CONFIG_HOME/crewster/config.toml` exists, it is used as the source in
 ### `crewster sync`
 
 Syncs local files to the remote HPC cluster using rsync.
-Always syncs the entire project root (where `crewster.toml` is located), regardless of which subdirectory you run from.
+Always syncs the entire project root (where `crewster.toml` is located, or the `--project-dir` override), regardless of which subdirectory you run from.
 
 ```bash
 crewster sync                # sync files
@@ -160,8 +160,18 @@ For backward compatibility, the legacy `$HPC_CONFIG` environment variable and a 
 The directory containing `crewster.toml` is the **project root**. This affects:
 
 - **`crewster sync`**: always syncs the entire project root to `workdir`, regardless of CWD
-- **`crewster submit`**: sets the job's `cd` to `workdir` + (CWD relative to project root)
+- **`crewster exec` / `crewster submit`**: set the command's / job's `cd` to `workdir` + (CWD relative to project root)
 - **`.crewster/runs/`**: run metadata is always stored at the project root
+
+To keep the config file outside the working tree, pass `--project-dir` to override the derived project root:
+
+```bash
+crewster sync --config ~/configs/myproj.toml --project-dir ~/work/myproj
+```
+
+The override itself is never discovered — it must be passed explicitly, and the current directory is never implicitly treated as the root. Without the flag, the project root always comes from the config file's location.
+
+`--project-dir` requires the config to be explicit too (`--config` or `$CREWSTER_CONFIG`); combining it with walk-up discovery is rejected so a stray ancestor `crewster.toml` can never pair another project's cluster settings with the override tree. The override is per-invocation: commands that read run metadata (`status`, `list`, `job-output`, `wait`) must be given the same `--project-dir` the run was submitted with.
 
 `crewster init` does not walk up — it always creates `crewster.toml` in the current directory.
 

--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -51,6 +51,17 @@ ConfigOption = Annotated[
 WorkdirOption = Annotated[
     Optional[str], typer.Option("--workdir", "-w", help="Override remote workdir")
 ]
+ProjectDirOption = Annotated[
+    Optional[Path],
+    typer.Option(
+        "--project-dir",
+        help=(
+            "Override the project root (default: the config file's directory). "
+            "The project root is the local sync root, the base for the remote "
+            "working-directory offset, and where .crewster/runs is stored."
+        ),
+    ),
+]
 
 
 def _warn_legacy(message: str) -> None:
@@ -67,13 +78,19 @@ def _resolve_config_path(
     config_path: Optional[Path],
     walk_up: bool = True,
     allow_legacy: bool = True,
-) -> Path:
-    """Resolve the config path.
+) -> tuple[Path, bool]:
+    """Resolve the config path, returning ``(path, explicit)``.
 
     Order: ``--config`` > ``$CREWSTER_CONFIG`` > ``$HPC_CONFIG`` > walk-up
     discovery (``crewster.toml`` then legacy ``hpc.toml``) > CWD
     ``crewster.toml``. The legacy env var and legacy filename are read-only
     fallbacks that emit a deprecation warning and are removed by v1.0.
+
+    ``explicit`` is True when the user named the config directly (flag or an
+    env var, the deprecated ``$HPC_CONFIG`` included) and False when it was
+    discovered (walk-up or the CWD fallback). Provenance is reported here —
+    the one place that owns the precedence order — so consumers such as the
+    ``--project-dir`` guard cannot drift from the resolution branches.
 
     ``allow_legacy=False`` (used by ``init``) drops every legacy branch, so the
     command never resolves to ``$HPC_CONFIG`` nor to an ``hpc.toml`` name and
@@ -81,15 +98,19 @@ def _resolve_config_path(
     arbitrary user path and never triggers a deprecation warning regardless of
     its filename.
     """
+    # Explicit sources are expanded here so a tilde the shell did not expand
+    # (quoted flag value, env var set outside a shell) resolves the same way
+    # ``--project-dir`` and ``sync.pull_dir`` do. Discovered paths cannot
+    # contain a tilde, so the walk-up / CWD branches need no expansion.
     if config_path:
-        return config_path
+        return _expand_user_path(config_path, "--config"), True
     if env_config := os.environ.get("CREWSTER_CONFIG"):
-        return Path(env_config)
+        return _expand_user_path(Path(env_config), "$CREWSTER_CONFIG"), True
     if allow_legacy and (env_config := os.environ.get("HPC_CONFIG")):
         _warn_legacy(
             "$HPC_CONFIG is deprecated; use $CREWSTER_CONFIG (removed in v1.0)"
         )
-        return Path(env_config)
+        return _expand_user_path(Path(env_config), "$HPC_CONFIG"), True
     if walk_up:
         names = ("crewster.toml", "hpc.toml") if allow_legacy else ("crewster.toml",)
         found = find_config(names)
@@ -100,19 +121,67 @@ def _resolve_config_path(
                     f"{path} uses the legacy name 'hpc.toml'; "
                     "rename to 'crewster.toml' (removed in v1.0)"
                 )
-            return path
-    return Path("crewster.toml")
+            return path, False
+    return Path("crewster.toml"), False
 
 
-def _load_config(config_path: Optional[Path]) -> tuple[Path, Path, HpcConfig]:
-    """Resolve and load config, returning config path, project root, and config"""
-    path = _resolve_config_path(config_path)
+def _expand_user_path(path: Path, label: str) -> Path:
+    """``expanduser`` with the CLI's error convention.
+
+    A tilde the shell did not expand (quoted, or injected from a script) must
+    still resolve, but ``Path.expanduser`` raises ``RuntimeError`` for an
+    unknown user (``~nosuchuser/...``) or an undeterminable home directory —
+    turn that into the clean exit-1 error the surrounding validation promises
+    instead of a traceback.
+    """
+    try:
+        return path.expanduser()
+    except RuntimeError:
+        print(f"Cannot expand user in {label}: {path}")
+        raise typer.Exit(1) from None
+
+
+def _load_config(
+    config_path: Optional[Path], project_dir: Optional[Path]
+) -> tuple[Path, HpcConfig]:
+    """Resolve and load config, returning the project root and the config.
+
+    The project root defaults to the config file's parent directory, which
+    keeps the config an in-tree anchor. ``project_dir`` overrides it for
+    layouts where the config lives outside the working tree; the override is
+    an explicit path only — never discovered, never implied by CWD. It is
+    validated here so every consumer receives an existing, resolved directory
+    (``relative_to`` comparisons downstream require an absolute path).
+    ``project_dir`` is deliberately non-defaulted so every command states its
+    choice — a command cannot accept ``--project-dir`` yet forget to forward it.
+
+    ``project_dir`` additionally requires the config itself to be explicit
+    (``--config`` or a config env var): pairing an explicit root with a
+    walk-up-discovered config would let a stray ancestor ``crewster.toml``
+    silently supply another project's cluster settings for the override tree.
+    """
+    path, explicit = _resolve_config_path(config_path)
+    if project_dir is not None and not explicit:
+        print(
+            "--project-dir requires an explicit config: "
+            "pass --config or set $CREWSTER_CONFIG"
+        )
+        raise typer.Exit(1)
     if not path.exists():
         print(f"Config file not found: {path}")
         raise typer.Exit(1)
     manager = ConfigManager()
-    project_root = path.resolve().parent
-    return path, project_root, manager.load_config(path)
+    if project_dir is not None:
+        # ``is_dir()`` is False for both a missing path and an existing
+        # non-directory, so one check rejects both misuses.
+        project_dir = _expand_user_path(project_dir, "--project-dir")
+        if not project_dir.is_dir():
+            print(f"Project directory not found or not a directory: {project_dir}")
+            raise typer.Exit(1)
+        project_root = project_dir.resolve()
+    else:
+        project_root = path.resolve().parent
+    return project_root, manager.load_config(path)
 
 
 def _get_user_config_path() -> Path:
@@ -170,7 +239,7 @@ def init(
     """Initialize HPC project configuration"""
     # ``allow_legacy=False`` keeps init from ever resolving to $HPC_CONFIG or an
     # hpc.toml name, so it writes crewster.toml only and never the legacy file.
-    config_path = _resolve_config_path(config, walk_up=False, allow_legacy=False)
+    config_path, _ = _resolve_config_path(config, walk_up=False, allow_legacy=False)
     if config_path.exists():
         print(f"Config file already exists: {config_path}")
         return
@@ -194,9 +263,10 @@ def sync(
     pull: bool = typer.Option(False, "--pull", help="Only pull remote to local"),
     workdir: WorkdirOption = None,
     config: ConfigOption = None,
+    project_dir: ProjectDirOption = None,
 ):
     """Sync files bidirectionally with remote HPC cluster (push then pull)"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
     if workdir:
         hpc_config.cluster.workdir = workdir
 
@@ -238,7 +308,9 @@ def sync(
     if do_pull:
         pull_dir = None
         if hpc_config.sync.pull_dir:
-            pull_dir = Path(hpc_config.sync.pull_dir).expanduser().resolve()
+            pull_dir = _expand_user_path(
+                Path(hpc_config.sync.pull_dir), "sync.pull_dir"
+            ).resolve()
             if not dry_run:
                 pull_dir.mkdir(parents=True, exist_ok=True)
             print(f"==> Pull (remote → {pull_dir})")
@@ -282,9 +354,10 @@ def exec_cmd(
         Optional[str], typer.Option("--workdir", help="Override remote workdir")
     ] = None,
     config: ConfigOption = None,
+    project_dir: ProjectDirOption = None,
 ):
     """Execute a command on the login node (not via scheduler)"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
     if workdir:
         hpc_config.cluster.workdir = workdir
 
@@ -342,9 +415,10 @@ def submit(
         Optional[str], typer.Option("--workdir", help="Override remote workdir")
     ] = None,
     config: ConfigOption = None,
+    project_dir: ProjectDirOption = None,
 ):
     """Submit a job to the scheduler"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
     if workdir:
         hpc_config.cluster.workdir = workdir
 
@@ -448,9 +522,10 @@ def status(
         help="For array / het jobs: 'summary' (aggregate line) or 'tasks' (per-task blocks)",
     ),
     config: ConfigOption = None,
+    project_dir: ProjectDirOption = None,
 ):
     """Check job status (accepts run_id or job_id)"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
 
     if not id:
         print("Please specify a run_id or job_id")
@@ -523,9 +598,9 @@ def status(
 
 
 @app.command(name="list")
-def list_runs(config: ConfigOption = None):
+def list_runs(config: ConfigOption = None, project_dir: ProjectDirOption = None):
     """List all runs"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
 
     runs_dir = project_root / ".crewster" / "runs"
     run_manager = RunManager(config=hpc_config, runs_dir=runs_dir)
@@ -553,9 +628,10 @@ def job_output(
         help="Stream output as the job runs (tail -F equivalent)",
     ),
     config: ConfigOption = None,
+    project_dir: ProjectDirOption = None,
 ):
     """Show job output (accepts run_id or job_id)"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
 
     runs_dir = project_root / ".crewster" / "runs"
     run_manager = RunManager(config=hpc_config, runs_dir=runs_dir)
@@ -588,9 +664,9 @@ def job_output(
 
 
 @app.command()
-def wait(id: str, config: ConfigOption = None):
+def wait(id: str, config: ConfigOption = None, project_dir: ProjectDirOption = None):
     """Wait for a run to complete (accepts run_id or job_id)"""
-    config_path, project_root, hpc_config = _load_config(config)
+    project_root, hpc_config = _load_config(config, project_dir)
 
     runs_dir = project_root / ".crewster" / "runs"
     run_manager = RunManager(config=hpc_config, runs_dir=runs_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from crewster.main import app
 from crewster import cli  # noqa: F401 - register commands
 
@@ -662,8 +664,9 @@ def test_resolve_crewster_env_wins_over_legacy(temp_dir, monkeypatch, capsys):
     monkeypatch.chdir(temp_dir)
     monkeypatch.setenv("CREWSTER_CONFIG", "/new/crewster.toml")
     monkeypatch.setenv("HPC_CONFIG", "/old/hpc.toml")
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == Path("/new/crewster.toml")
+    assert explicit
     assert capsys.readouterr().err == ""
 
 
@@ -671,8 +674,9 @@ def test_resolve_legacy_env_warns(temp_dir, monkeypatch, capsys):
     """A lone $HPC_CONFIG is honored but warns on stderr."""
     monkeypatch.chdir(temp_dir)
     monkeypatch.setenv("HPC_CONFIG", "/old/hpc.toml")
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == Path("/old/hpc.toml")
+    assert explicit
     assert "HPC_CONFIG" in capsys.readouterr().err
 
 
@@ -681,8 +685,9 @@ def test_resolve_explicit_config_never_warns(temp_dir, monkeypatch, capsys):
     even when its basename is the legacy hpc.toml."""
     monkeypatch.chdir(temp_dir)
     legacy = temp_dir / "hpc.toml"
-    path = cli._resolve_config_path(legacy)
+    path, explicit = cli._resolve_config_path(legacy)
     assert path == legacy
+    assert explicit
     assert capsys.readouterr().err == ""
 
 
@@ -690,8 +695,9 @@ def test_resolve_walk_up_crewster_no_warn(temp_dir, monkeypatch, capsys):
     """Walk-up discovery of crewster.toml emits no warning."""
     (temp_dir / "crewster.toml").write_text("x")
     monkeypatch.chdir(temp_dir)
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == (temp_dir / "crewster.toml").resolve()
+    assert not explicit
     assert capsys.readouterr().err == ""
 
 
@@ -699,8 +705,9 @@ def test_resolve_walk_up_legacy_warns(temp_dir, monkeypatch, capsys):
     """Walk-up discovery falling back to hpc.toml warns on stderr."""
     (temp_dir / "hpc.toml").write_text("x")
     monkeypatch.chdir(temp_dir)
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == (temp_dir / "hpc.toml").resolve()
+    assert not explicit
     assert "hpc.toml" in capsys.readouterr().err
 
 
@@ -709,8 +716,9 @@ def test_resolve_crewster_wins_same_dir(temp_dir, monkeypatch, capsys):
     (temp_dir / "crewster.toml").write_text("x")
     (temp_dir / "hpc.toml").write_text("x")
     monkeypatch.chdir(temp_dir)
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == (temp_dir / "crewster.toml").resolve()
+    assert not explicit
     assert capsys.readouterr().err == ""
 
 
@@ -722,8 +730,9 @@ def test_resolve_nearest_legacy_beats_ancestor_crewster(temp_dir, monkeypatch, c
     child.mkdir()
     (child / "hpc.toml").write_text("x")
     monkeypatch.chdir(child)
-    path = cli._resolve_config_path(None)
+    path, explicit = cli._resolve_config_path(None)
     assert path == (child / "hpc.toml").resolve()
+    assert not explicit
     assert "hpc.toml" in capsys.readouterr().err
 
 
@@ -746,11 +755,9 @@ def test_walk_up_finds_config(cli_runner, temp_dir, monkeypatch):
     child = temp_dir / "runs" / "bench1"
     child.mkdir(parents=True)
     monkeypatch.chdir(child)
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        result = cli_runner.invoke(app, ["sync"])
-        assert result.exit_code == 0
-        assert "Config file not found" not in result.stdout
+    result, _ = _sync_rsync_args(cli_runner, ["sync"])
+    assert result.exit_code == 0
+    assert "Config file not found" not in result.stdout
 
 
 def test_sync_uses_project_root(cli_runner, temp_dir, monkeypatch):
@@ -761,15 +768,218 @@ def test_sync_uses_project_root(cli_runner, temp_dir, monkeypatch):
     child = temp_dir / "runs" / "bench1"
     child.mkdir(parents=True)
     monkeypatch.chdir(child)
+    _, call_args = _sync_rsync_args(cli_runner, ["sync"])
+    # rsync should use project root, not the child directory
+    assert any(str(temp_dir.resolve()) in str(a) for a in call_args)
+    # Should NOT contain the child subpath as the source
+    assert not any(str(child) in str(a) for a in call_args)
+
+
+def _project_dir_layout(temp_dir) -> tuple[Path, Path]:
+    """Config outside the working tree: config in ``configs/``, work in
+    ``project/``. Returns (config file, project dir)."""
+    config_dir = temp_dir / "configs"
+    config_dir.mkdir()
+    config = config_dir / "crewster.toml"
+    config.write_text("[cluster]\nhost = 'test'\nworkdir = '/tmp'")
+    project = temp_dir / "project"
+    project.mkdir()
+    return config, project
+
+
+def _sync_rsync_args(cli_runner, args):
+    """Invoke ``sync`` with subprocess mocked out; return (result, argv).
+
+    ``argv`` flattens every ``subprocess.run`` invocation (remote-dir check,
+    push rsync, pull rsync), so path assertions cover both sync directions
+    rather than just the final call.
+    """
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        cli_runner.invoke(app, ["sync"])
-        # rsync should use project root, not the child directory
-        call_args = mock_run.call_args[0][0]
-        local_arg = [a for a in call_args if str(temp_dir.resolve()) in str(a)]
-        assert local_arg
-        # Should NOT contain the child subpath as the source
-        assert not any(str(child) in str(a) for a in call_args)
+        result = cli_runner.invoke(app, args)
+        call_args = [arg for call in mock_run.call_args_list for arg in call[0][0]]
+    return result, call_args
+
+
+def test_sync_project_dir_overrides_local_root(cli_runner, temp_dir, monkeypatch):
+    """--project-dir makes sync use the override as the rsync local root,
+    not the config file's parent directory"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner, ["sync", "--config", str(config), "--project-dir", str(project)]
+    )
+    assert result.exit_code == 0
+    assert any(str(project.resolve()) in str(a) for a in call_args)
+    assert not any(str(config.parent.resolve()) in str(a) for a in call_args)
+
+
+def _missing_path(temp_dir) -> Path:
+    return temp_dir / "missing"
+
+
+def _file_path(temp_dir) -> Path:
+    not_a_dir = temp_dir / "not_a_dir"
+    not_a_dir.write_text("")
+    return not_a_dir
+
+
+@pytest.mark.parametrize(
+    "make_bad_path", [_missing_path, _file_path], ids=["missing", "file"]
+)
+def test_project_dir_invalid_path_errors(
+    cli_runner, temp_dir, monkeypatch, make_bad_path
+):
+    """A --project-dir path that is missing or not a directory exits 1"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner,
+        [
+            "sync",
+            "--config",
+            str(config),
+            "--project-dir",
+            str(make_bad_path(temp_dir)),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Project directory not found or not a directory" in result.stdout
+    # Validation must fire before any remote command is attempted.
+    assert call_args == []
+
+
+def test_project_dir_requires_explicit_config(cli_runner, temp_dir, monkeypatch):
+    """--project-dir without --config / $CREWSTER_CONFIG exits 1 instead of
+    pairing the override with a walk-up-discovered config"""
+    config, project = _project_dir_layout(temp_dir)
+    # A stray config above CWD that walk-up discovery would latch onto.
+    (temp_dir / "crewster.toml").write_text(config.read_text())
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner, ["sync", "--project-dir", str(project)]
+    )
+    assert result.exit_code == 1
+    assert "--project-dir requires an explicit config" in result.stdout
+    # The guard must reject before any remote command is attempted.
+    assert call_args == []
+
+
+@pytest.mark.parametrize("env_var", ["CREWSTER_CONFIG", "HPC_CONFIG"])
+def test_project_dir_with_env_config(cli_runner, temp_dir, monkeypatch, env_var):
+    """An env-var config (including the legacy $HPC_CONFIG) counts as an
+    explicit config for --project-dir"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.setenv(env_var, str(config))
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner, ["sync", "--project-dir", str(project)]
+    )
+    assert result.exit_code == 0
+    assert any(str(project.resolve()) in str(a) for a in call_args)
+
+
+def test_config_expands_tilde(cli_runner, temp_dir, monkeypatch):
+    """A literal tilde in --config (unexpanded by the shell) is expanded,
+    matching the --project-dir behavior on the same command line"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.setenv("HOME", str(temp_dir))
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner,
+        ["sync", "--config", "~/configs/crewster.toml", "--project-dir", str(project)],
+    )
+    assert result.exit_code == 0
+    assert any(str(project.resolve()) in str(a) for a in call_args)
+
+
+def test_project_dir_unknown_user_tilde_errors(cli_runner, temp_dir, monkeypatch):
+    """A tilde path naming an unknown user exits 1 cleanly instead of
+    surfacing Path.expanduser's RuntimeError as a traceback"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner,
+        [
+            "sync",
+            "--config",
+            str(config),
+            "--project-dir",
+            "~no_such_user_crewster_test/proj",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Cannot expand user in --project-dir" in result.stdout
+    # Validation must fire before any remote command is attempted.
+    assert call_args == []
+
+
+def test_project_dir_expands_tilde(cli_runner, temp_dir, monkeypatch):
+    """A literal tilde path (unexpanded by the shell) is expanded, mirroring
+    pull_dir handling"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.setenv("HOME", str(temp_dir))
+    monkeypatch.chdir(project)
+    result, call_args = _sync_rsync_args(
+        cli_runner, ["sync", "--config", str(config), "--project-dir", "~/project"]
+    )
+    assert result.exit_code == 0
+    assert any(str(project.resolve()) in str(a) for a in call_args)
+
+
+def _submit_with_project_dir(cli_runner, config, project):
+    """Invoke ``submit`` with --project-dir under a mocked JobManager.
+    Returns (result, mocked JobManager instance)."""
+    with patch("crewster.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.submit_run.return_value = "12345678"
+        result = cli_runner.invoke(
+            app,
+            [
+                "submit",
+                "echo hi",
+                "--config",
+                str(config),
+                "--project-dir",
+                str(project),
+            ],
+        )
+    return result, instance
+
+
+def test_submit_run_metadata_under_project_dir(cli_runner, temp_dir, monkeypatch):
+    """Run metadata (.crewster/runs) is created under the override, not next
+    to the config file"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.chdir(project)
+    result, _ = _submit_with_project_dir(cli_runner, config, project)
+    assert result.exit_code == 0
+    assert (project / ".crewster" / "runs").is_dir()
+    assert not (config.parent / ".crewster").exists()
+
+
+def test_submit_cwd_relative_inside_project_dir(cli_runner, temp_dir, monkeypatch):
+    """With CWD inside a subdirectory of the override, the remote offset is
+    that subdirectory (the positive cwd_relative path, not the fallback)"""
+    config, project = _project_dir_layout(temp_dir)
+    subdir = project / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    result, instance = _submit_with_project_dir(cli_runner, config, project)
+    assert result.exit_code == 0
+    assert instance.submit_run.call_args.kwargs["cwd_relative"] == Path("subdir")
+
+
+def test_submit_cwd_relative_outside_project_dir_falls_back(
+    cli_runner, temp_dir, monkeypatch
+):
+    """With CWD outside the overridden project root, the offset falls back to
+    the root itself (existing ValueError fallback preserved)"""
+    config, project = _project_dir_layout(temp_dir)
+    monkeypatch.chdir(config.parent)
+    result, instance = _submit_with_project_dir(cli_runner, config, project)
+    assert result.exit_code == 0
+    assert instance.submit_run.call_args.kwargs["cwd_relative"] == Path(".")
 
 
 def test_init_does_not_walk_up(cli_runner, temp_dir, monkeypatch):


### PR DESCRIPTION
## Summary

crewster derived the project root — the local sync root, the base for the remote working-directory offset (how the CWD relative to the root maps onto the remote `workdir`), and the `.crewster/runs` location — from the config file's parent directory, which made it impossible to keep the config file outside the working tree. This PR adds an explicit `--project-dir <path>` override to every config-loading command. Closes #41

## Changes

- `src/crewster/cli.py`: `ProjectDirOption` added to `sync`, `exec`, `submit`, `status`, `list`, `job-output`, and `wait` (`init` derives no project root and is excluded). `_load_config` validates the override (tilde-expanded, must exist and be a directory, resolved) before any consumer sees it.
- `--project-dir` requires an explicit config (`--config` or a config env var): pairing the override with walk-up discovery is rejected so a stray ancestor `crewster.toml` can never supply another project's cluster settings for the override tree. `_resolve_config_path` now returns `(path, explicit)` so provenance comes from the single function that owns the precedence order.
- Tilde expansion unified: `--config`, the config env vars, `--project-dir`, and `sync.pull_dir` all pass through a shared `_expand_user_path` helper that converts `Path.expanduser`'s `RuntimeError` for an unknown user into an error message plus exit code 1, matching how the CLI reports other bad-path inputs.
- `_load_config` now returns `(project_root, config)`; the previously returned config path was unused by every caller.
- `README.md` and `.claude/skills/crewster/SKILL.md` document the override, the explicit-config requirement, and the per-invocation nature of the flag.

## Impact

All seven config-loading commands gain the option; without the flag, behavior is unchanged (config parent = project root). `_load_config` and `_resolve_config_path` are module-private with no callers outside `cli.py`.

Behavior change independent of the new flag: an unexpanded tilde in `--config` / `$CREWSTER_CONFIG` / `$HPC_CONFIG` now expands instead of failing the existence check, and `crewster init --config '~/x/crewster.toml'` accordingly writes into the home directory rather than creating a literal `./~` tree.

## Test plan

Tests added / extended in `tests/test_cli.py`; full suite passes (368 tests, `uv run pytest`):

- sync uses the override as the rsync local root, not the config parent
- missing / non-directory / unknown-user-tilde `--project-dir` values exit 1 before any remote command is attempted
- `--project-dir` without an explicit config is rejected; `$CREWSTER_CONFIG` and the legacy `$HPC_CONFIG` both count as explicit
- tilde expansion for `--project-dir` and `--config`
- run metadata is created under the override
- remote working-directory offset: a subdirectory of the override maps to that subdirectory; a CWD outside the root keeps the existing fallback (the command runs at the remote `workdir` root)
- all five config-resolution branches (`--config`, `$CREWSTER_CONFIG`, `$HPC_CONFIG`, walk-up hit, CWD fallback) assert their `explicit` provenance flag

## Notes

The override is per-invocation: metadata-reading commands (`status`, `list`, `job-output`, `wait`) must be given the same `--project-dir` the run was submitted with. A `$CREWSTER_PROJECT_DIR` environment variable is deliberately not included (deferred in #41). Follow-ups: #43 (`--script` tilde expansion), #44 (metadata lookups create `.crewster/runs` under the wrong root).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--project-dir` option to several commands, letting you run them against a specific project root.
  * Run metadata and sync behavior now consistently follow the selected project root.

* **Bug Fixes**
  * Improved config handling and path expansion for clearer, more reliable command behavior.
  * Added validation so invalid project directories are rejected early.

* **Documentation**
  * Clarified how project root selection works across commands, including override rules and metadata lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->