### PR TITLE
docs(cli): state that --config's directory is the default project root

### DIFF
--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -46,7 +46,15 @@ class DetailMode(str, Enum):
 
 # Type alias for config option
 ConfigOption = Annotated[
-    Optional[Path], typer.Option("--config", "-c", help="Config file path")
+    Optional[Path],
+    typer.Option(
+        "--config",
+        "-c",
+        help=(
+            "Config file path. Its directory is the default project "
+            "root (the local sync root)."
+        ),
+    ),
 ]
 WorkdirOption = Annotated[
     Optional[str], typer.Option("--workdir", "-w", help="Override remote workdir")


### PR DESCRIPTION
## Summary

The `--config` help said only "Config file path", but passing a config file also silently determines the project root: `_load_config` derives it from the config file's directory, which becomes the local root of the tree `crewster sync` transfers. A user cannot discover this behavior without reading the source. This PR states the side effect in the help string, qualified as the default so it stays consistent with the adjacent `--project-dir` help, which documents the override.

Closes #40

## Changes

- `src/crewster/cli.py` — extend the shared `ConfigOption` help to "Config file path. Its directory is the default project root (the local sync root)."

## Test plan

- Help-text-only change; the full test suite passes (`uv run pytest`, 368 tests).
- Verified that `crewster sync --help` and `crewster init --help` render the new text.

## Notes

The help deliberately does not name `--project-dir`: the `ConfigOption` alias is shared by `init`, which does not accept that flag, and every command that accepts both renders the `--project-dir` help directly alongside.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the command-line configuration option formatting for improved readability. No behavior, help text, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->