### PR TITLE
fix: create runs_dir only on write paths, not in RunManager.__init__

### DIFF
--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -192,6 +192,30 @@ def _load_config(
     return project_root, manager.load_config(path)
 
 
+def _print_run_not_found(id: str, run_manager: RunManager) -> None:
+    """Report a failed run lookup with the directory it searched.
+
+    A miss with no runs recorded at all is compatible with two causes — a
+    project-root mismatch (the command was invoked with a different
+    ``--project-dir`` / ``--config`` than at submit time, issue #44's
+    scenario) or simply nothing submitted from this root yet — so the hint
+    states the fact (no runs here) and phrases the remedy conditionally
+    rather than presuming the mismatch. With runs present, the id itself is
+    the likely problem and the hint would only misdirect. Emptiness is
+    judged by ``list_runs`` — the manager's own definition of a recorded
+    run — so stray entries (``.DS_Store``, a metadata-less dir left by an
+    aborted submit) cannot suppress the hint, and the missing-directory
+    case stays handled in one place.
+    """
+    print(f"Run not found: {id}")
+    if not run_manager.list_runs():
+        print(
+            f"(no runs recorded under {run_manager.runs_dir} — if you "
+            "submitted from a different project root, invoke with the same "
+            "--project-dir/--config as at submit time)"
+        )
+
+
 def _get_user_config_path() -> Path:
     """Get user config path from XDG_CONFIG_HOME/crewster/config.toml"""
     xdg_config = os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
@@ -651,7 +675,7 @@ def job_output(
         run = run_manager.find_run_by_job_id(id)
 
     if not run:
-        print(f"Run not found: {id}")
+        _print_run_not_found(id, run_manager)
         raise typer.Exit(1)
 
     if not run.job_id:
@@ -686,7 +710,7 @@ def wait(id: str, config: ConfigOption = None, project_dir: ProjectDirOption = N
         run = run_manager.find_run_by_job_id(id)
 
     if not run:
-        print(f"Run not found: {id}")
+        _print_run_not_found(id, run_manager)
         raise typer.Exit(1)
 
     if not run.job_id:

--- a/src/crewster/run.py
+++ b/src/crewster/run.py
@@ -24,12 +24,17 @@ class RunConfig:
 
 
 class RunManager:
-    """Manages run lifecycle and metadata"""
+    """Manages run lifecycle and metadata.
+
+    ``runs_dir`` is created lazily by the write paths (``create_run`` /
+    ``save_run_meta``), never at construction time: read-only lookups must not
+    leave an empty ``.crewster/runs`` tree behind when invoked against a
+    project root that has no runs (e.g. a wrong ``--project-dir``).
+    """
 
     def __init__(self, config: HpcConfig, runs_dir: Path):
         self.config = config
         self.runs_dir = runs_dir
-        self.runs_dir.mkdir(parents=True, exist_ok=True)
 
     def _generate_run_id(self) -> str:
         """Generate unique run ID: YYYY-MM-DD_HHMMSS_<hash>"""
@@ -77,9 +82,18 @@ class RunManager:
         return RunConfig(**filtered_data)
 
     def list_runs(self) -> list[RunConfig]:
-        """List all runs"""
+        """List all runs; a missing ``runs_dir`` reads as "no runs".
+
+        EAFP instead of an ``is_dir()`` pre-check: no window between check
+        and iteration, and a ``runs_dir`` that exists as a regular file
+        still fails loudly instead of masquerading as an empty run list.
+        """
+        try:
+            run_dirs = list(self.runs_dir.iterdir())
+        except FileNotFoundError:
+            return []
         runs = []
-        for run_dir in self.runs_dir.iterdir():
+        for run_dir in run_dirs:
             if run_dir.is_dir():
                 meta_path = run_dir / "meta.toml"
                 if meta_path.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1062,3 +1062,86 @@ def test_job_output_without_follow_uses_get_job_output(
         mock_job.get_job_output.assert_called_once_with("r1", "12345678", error=False)
         mock_job.tail_job_output.assert_not_called()
         assert "static output" in result.stdout
+
+
+def test_wait_unknown_id_does_not_create_runs_dir(cli_runner, temp_dir, monkeypatch):
+    """A failed lookup must not leave an empty .crewster tree behind:
+    lookup commands only read run metadata and create nothing
+    (https://github.com/ultimatile/crewster/issues/44)."""
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    result = cli_runner.invoke(app, ["wait", "nonexistent"])
+
+    assert result.exit_code == 1
+    assert "Run not found: nonexistent" in result.stdout
+    # With no runs recorded, the project-root hint fires.
+    assert "no runs recorded" in result.stdout
+    assert not (temp_dir / ".crewster").exists()
+
+
+def test_wait_unknown_id_with_stray_entries_still_hints(
+    cli_runner, temp_dir, monkeypatch
+):
+    """Entries that are not recorded runs — a stray file, or a metadata-less
+    dir left by an aborted submit — must not suppress the project-root hint:
+    emptiness is defined by list_runs, not by raw directory contents."""
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+    runs_dir = temp_dir / ".crewster" / "runs"
+    runs_dir.mkdir(parents=True)
+    (runs_dir / ".DS_Store").write_text("")
+    (runs_dir / "aborted_run").mkdir()
+
+    result = cli_runner.invoke(app, ["wait", "nonexistent"])
+
+    assert result.exit_code == 1
+    assert "Run not found: nonexistent" in result.stdout
+    assert "no runs recorded" in result.stdout
+
+
+def test_wait_unknown_id_with_existing_runs_omits_root_hint(
+    cli_runner, temp_dir, monkeypatch
+):
+    """With run metadata present, a lookup miss points at the id itself,
+    not a project-root mismatch, so the hint is suppressed."""
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    result = cli_runner.invoke(app, ["wait", "unknown-id"])
+
+    assert result.exit_code == 1
+    assert "Run not found: unknown-id" in result.stdout
+    assert "no runs recorded" not in result.stdout
+
+
+def test_list_without_runs_dir_prints_no_runs(cli_runner, temp_dir, monkeypatch):
+    """`list` in a fresh project reports no runs without creating .crewster
+    (https://github.com/ultimatile/crewster/issues/44)."""
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    result = cli_runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "No runs found." in result.stdout
+    assert not (temp_dir / ".crewster").exists()
+
+
+def test_status_unknown_id_does_not_create_runs_dir(cli_runner, temp_dir, monkeypatch):
+    """An unknown id falls back to scheduler lookup (mocked here), and the
+    metadata miss must not create .crewster
+    (https://github.com/ultimatile/crewster/issues/44)."""
+    from crewster.job import JobStatus
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("crewster.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = []
+        instance.get_job_status.return_value = JobStatus.PENDING
+        result = cli_runner.invoke(app, ["status", "12345678"])
+
+    assert result.exit_code == 0
+    assert not (temp_dir / ".crewster").exists()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -100,6 +100,46 @@ class TestRunManagerSaveLoad:
         assert loaded.job_id == "12345678"
 
 
+class TestRunManagerLazyRunsDir:
+    """runs_dir is created by write paths only, never by lookups, so a
+    metadata lookup against the wrong project root leaves no trace
+    (https://github.com/ultimatile/crewster/issues/44)."""
+
+    @pytest.fixture
+    def runs_dir(self, temp_dir):
+        """A runs_dir path that does not exist yet."""
+        return temp_dir / ".crewster" / "runs"
+
+    @pytest.fixture
+    def manager(self, sample_config, runs_dir):
+        return RunManager(config=sample_config, runs_dir=runs_dir)
+
+    def test_init_does_not_create_runs_dir(self, manager, runs_dir):
+        assert not runs_dir.exists()
+
+    def test_list_runs_missing_dir_returns_empty(self, manager, runs_dir):
+        assert manager.list_runs() == []
+        assert not runs_dir.exists()
+
+    def test_find_run_by_job_id_missing_dir_returns_none(self, manager, runs_dir):
+        assert manager.find_run_by_job_id("12345678") is None
+        assert not runs_dir.exists()
+
+    def test_load_run_meta_missing_dir_raises(self, manager, runs_dir):
+        with pytest.raises(FileNotFoundError):
+            manager.load_run_meta("nonexistent")
+        assert not runs_dir.exists()
+
+    def test_create_run_creates_missing_runs_dir(self, manager, runs_dir):
+        run = manager.create_run("python train.py")
+        assert (runs_dir / run.run_id).is_dir()
+
+    def test_save_run_meta_creates_missing_runs_dir(self, manager, runs_dir):
+        run = RunConfig(run_id="r1", cmd="echo hi", status="pending")
+        manager.save_run_meta(run)
+        assert (runs_dir / "r1" / "meta.toml").exists()
+
+
 class TestRunManagerList:
     def test_list_runs_empty(self, sample_config, temp_dir):
         manager = RunManager(config=sample_config, runs_dir=temp_dir)


### PR DESCRIPTION
## Summary

Metadata-lookup commands (`status`, `list`, `job-output`, `wait`) invoked against the wrong project root used to create an empty `.crewster/runs` tree there before printing `Run not found`, because `RunManager.__init__` unconditionally ran `mkdir(parents=True, exist_ok=True)`. Directory creation now happens only on write paths, and failed lookups leave the filesystem untouched. Closes #44

## Changes

- `src/crewster/run.py`: removed the `mkdir` from `RunManager.__init__`; `create_run` and `save_run_meta` already create their run directory with `parents=True`, which covers `runs_dir`. `list_runs` treats a missing `runs_dir` as "no runs" — EAFP around `iterdir`, so a `runs_dir` that exists as a regular file still fails loudly.
- `src/crewster/cli.py`: new `_print_run_not_found` helper used by `job-output` and `wait` on a failed lookup. When no runs are recorded under the searched root, it names that directory and notes, conditionally, that a run submitted from a different project root must be looked up with the same `--project-dir`/`--config` as at submit time. The hint gates on `list_runs` (the manager's definition of a recorded run), so stray entries such as `.DS_Store` or a metadata-less directory cannot suppress it.

## Impact

- `submit` is unaffected (its write path creates the directory).
- `status` / `list` / `job-output` / `wait` lose the `mkdir` side effect; `load_run_meta` still raises `FileNotFoundError` for a missing tree, which the id-lookup commands (`status`, `job-output`, `wait`) already catch, and `crewster list` in a fresh project still prints `No runs found.`

## Test plan

Invariant: a failed metadata lookup never creates `.crewster/runs`.

- `tests/test_run.py`: `__init__` creates nothing; `list_runs` / `find_run_by_job_id` / `load_run_meta` on a missing `runs_dir` return `[]` / `None` / raise without touching the filesystem; `create_run` and `save_run_meta` create the tree when missing.
- `tests/test_cli.py`: `wait` and `status` with an unknown id and `list` in a fresh project leave `.crewster` uncreated; the hint fires on an empty metadata tree, survives stray non-run entries, and is suppressed when runs are recorded.
- `pytest`: 379 passed; `ruff check` / `ruff format` / `pyright` clean.

## Notes

- `status` still queries the scheduler when an id matches no local run metadata, without reporting the metadata miss; its `Run not found` branch is unreachable for a non-empty argument. Tracked in #47.
- On a failed lookup the hint re-lists runs after `find_run_by_job_id` already did. The double scan on this error path is deliberate: it keeps the emptiness check inside `list_runs` instead of threading the run list from the lookup into the printing helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Run not found” messages with guidance when no run history is available.
  * Read-only commands no longer create an empty `.crewster` directory.
  * `list`, `status`, and `wait` now handle projects without recorded runs more cleanly.
  * Preserved clear errors for missing runs and jobs while avoiding unnecessary filesystem changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->