### PR TITLE
test: pin list_runs' loud failure on a runs_dir that is a file

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -130,6 +130,16 @@ class TestRunManagerLazyRunsDir:
             manager.load_run_meta("nonexistent")
         assert not runs_dir.exists()
 
+    def test_list_runs_runs_dir_is_file_raises(self, manager, runs_dir):
+        """Contract: an empty result means "no runs recorded", so only a
+        MISSING runs_dir may read as empty. A runs_dir path occupied by a
+        non-directory is corrupted state and must fail loudly instead of
+        masquerading as an empty run list."""
+        runs_dir.parent.mkdir(parents=True)
+        runs_dir.write_text("stray")
+        with pytest.raises(NotADirectoryError):
+            manager.list_runs()
+
     def test_create_run_creates_missing_runs_dir(self, manager, runs_dir):
         run = manager.create_run("python train.py")
         assert (runs_dir / run.run_id).is_dir()


### PR DESCRIPTION
#48 made `list_runs` treat a missing `runs_dir` as "no runs"; the flip side of that behavior is that an empty result must mean only "no runs recorded", so a `runs_dir` path occupied by a regular file must raise `NotADirectoryError` instead of masquerading as an empty run list. The `list_runs` docstring already claims this, but no test pins it: widening its `except FileNotFoundError` clause (e.g. to `OSError`) would silently convert the corrupted state into "no runs". This PR adds the contract test.

## Test plan

- The new test fails on the guard #48 replaced (`if not runs_dir.is_dir(): return []`): `is_dir()` is false for a regular file, so that implementation returned `[]` without raising, and `pytest.raises(NotADirectoryError)` would report the missing exception.
- `pytest`: 380 passed; `ruff check` / `ruff format` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure an invalid runs directory path is reported as an error rather than treated as an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->