### PR TITLE
fix(cli): report metadata miss in status when scheduler has no data

### DIFF
--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -578,10 +578,6 @@ def status(
         print(f"Run {run.run_id} has no job ID")
         raise typer.Exit(1)
 
-    if not job_id:
-        print(f"Run not found: {id}")
-        raise typer.Exit(1)
-
     ssh = SSHManager(host=hpc_config.cluster.host)
     job_manager = JobManager(ssh_manager=ssh, config=hpc_config)
 
@@ -595,6 +591,17 @@ def status(
         try:
             job_status = job_manager.get_job_status(job_id)
         except SchedulerError:
+            if run is None:
+                # The id failed both lookups: no local run metadata and no
+                # scheduler data. That is indistinguishable from accounting
+                # lag on a raw just-submitted job id, but it is exactly the
+                # project-root-mismatch shape issue #44 addressed in
+                # job-output/wait
+                # (https://github.com/ultimatile/crewster/issues/44), so
+                # report the metadata miss the same way rather than implying
+                # the scheduler knows the job.
+                _print_run_not_found(id, run_manager)
+                raise typer.Exit(1)
             print(
                 f"Job {job_id}: status unavailable yet (scheduler accounting not ready)"
             )

--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -594,12 +594,11 @@ def status(
             if run is None:
                 # The id failed both lookups: no local run metadata and no
                 # scheduler data. That is indistinguishable from accounting
-                # lag on a raw just-submitted job id, but it is exactly the
-                # project-root-mismatch shape issue #44 addressed in
-                # job-output/wait
-                # (https://github.com/ultimatile/crewster/issues/44), so
-                # report the metadata miss the same way rather than implying
-                # the scheduler knows the job.
+                # lag on a raw just-submitted job id, but run metadata lives
+                # under the project root used at submit time, so a wrong
+                # --project-dir/--config produces exactly this double miss.
+                # Report the metadata miss the way job-output/wait do rather
+                # than implying the scheduler knows the job.
                 _print_run_not_found(id, run_manager)
                 raise typer.Exit(1)
             print(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -408,10 +408,9 @@ def test_status_unknown_id_with_no_scheduler_data_reports_run_not_found(
 ):
     """An id that misses both lookups — no local run metadata AND no scheduler
     data — is reported as a metadata miss with the project-root hint, matching
-    job-output/wait since issue #44
-    (https://github.com/ultimatile/crewster/issues/44), instead of the
-    misleading accounting-lag message
-    (https://github.com/ultimatile/crewster/issues/47). Covers both detail
+    job-output/wait: run metadata lives under the project root used at submit
+    time, so a wrong --project-dir/--config produces exactly this double miss,
+    which the previous accounting-lag message misdirected. Covers both detail
     shapes that reach the fallback: [] (sacct has no row) and None (scheduler
     exposes no detail source, e.g. PJM)."""
     from crewster.scheduler import SchedulerError

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -402,15 +402,18 @@ def test_status_prints_friendly_message_when_status_unavailable(
     assert "scheduler accounting not ready" in result.stdout
 
 
+@pytest.mark.parametrize("detail", [[], None], ids=["no-row", "unsupported"])
 def test_status_unknown_id_with_no_scheduler_data_reports_run_not_found(
-    cli_runner, temp_dir, monkeypatch
+    cli_runner, temp_dir, monkeypatch, detail
 ):
     """An id that misses both lookups — no local run metadata AND no scheduler
     data — is reported as a metadata miss with the project-root hint, matching
     job-output/wait since issue #44
     (https://github.com/ultimatile/crewster/issues/44), instead of the
     misleading accounting-lag message
-    (https://github.com/ultimatile/crewster/issues/47)."""
+    (https://github.com/ultimatile/crewster/issues/47). Covers both detail
+    shapes that reach the fallback: [] (sacct has no row) and None (scheduler
+    exposes no detail source, e.g. PJM)."""
     from crewster.scheduler import SchedulerError
 
     monkeypatch.chdir(temp_dir)
@@ -418,7 +421,7 @@ def test_status_unknown_id_with_no_scheduler_data_reports_run_not_found(
 
     with patch("crewster.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
-        instance.get_job_detail.return_value = []
+        instance.get_job_detail.return_value = detail
         instance.get_job_status.side_effect = SchedulerError(
             "sacct returned no data row"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -380,12 +380,14 @@ def test_status_falls_back_when_detail_unavailable(cli_runner, temp_dir, monkeyp
 def test_status_prints_friendly_message_when_status_unavailable(
     cli_runner, temp_dir, monkeypatch
 ):
-    """SchedulerError on the fallback ``get_job_status`` becomes a friendly
-    "status unavailable yet" line instead of an SSHError stack."""
+    """For a known run, SchedulerError on the fallback ``get_job_status``
+    becomes a friendly "status unavailable yet" line instead of an SSHError
+    stack: run metadata proves the job was submitted, so the absence is
+    accounting lag, not a bad id."""
     from crewster.scheduler import SchedulerError
 
     monkeypatch.chdir(temp_dir)
-    cli_runner.invoke(app, ["init"])
+    _setup_run_meta(temp_dir)
 
     with patch("crewster.cli.JobManager") as MockJobManager:
         instance = MockJobManager.return_value
@@ -398,6 +400,58 @@ def test_status_prints_friendly_message_when_status_unavailable(
     assert result.exit_code == 0
     assert "Job 12345678: status unavailable yet" in result.stdout
     assert "scheduler accounting not ready" in result.stdout
+
+
+def test_status_unknown_id_with_no_scheduler_data_reports_run_not_found(
+    cli_runner, temp_dir, monkeypatch
+):
+    """An id that misses both lookups — no local run metadata AND no scheduler
+    data — is reported as a metadata miss with the project-root hint, matching
+    job-output/wait since issue #44
+    (https://github.com/ultimatile/crewster/issues/44), instead of the
+    misleading accounting-lag message
+    (https://github.com/ultimatile/crewster/issues/47)."""
+    from crewster.scheduler import SchedulerError
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    with patch("crewster.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = []
+        instance.get_job_status.side_effect = SchedulerError(
+            "sacct returned no data row"
+        )
+        result = cli_runner.invoke(app, ["status", "nonexistent"])
+
+    assert result.exit_code == 1
+    assert "Run not found: nonexistent" in result.stdout
+    # With no runs recorded, the project-root hint fires.
+    assert "no runs recorded" in result.stdout
+    assert "status unavailable yet" not in result.stdout
+
+
+def test_status_unknown_id_with_existing_runs_omits_root_hint(
+    cli_runner, temp_dir, monkeypatch
+):
+    """With unrelated run metadata present, a both-lookups miss points at the
+    id itself, not a project-root mismatch, so the hint is suppressed."""
+    from crewster.scheduler import SchedulerError
+
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    with patch("crewster.cli.JobManager") as MockJobManager:
+        instance = MockJobManager.return_value
+        instance.get_job_detail.return_value = []
+        instance.get_job_status.side_effect = SchedulerError(
+            "sacct returned no data row"
+        )
+        result = cli_runner.invoke(app, ["status", "unknown-id"])
+
+    assert result.exit_code == 1
+    assert "Run not found: unknown-id" in result.stdout
+    assert "no runs recorded" not in result.stdout
 
 
 def test_status_normalizes_decorated_cancelled_state(cli_runner, temp_dir, monkeypatch):


### PR DESCRIPTION
## Summary

`status` resolves its argument by trying it as a run id first and falling back to treating it as a scheduler job id, and the fallback made the `Run not found` branch dead code: an id with no local run metadata always proceeded to scheduler lookup, and when the scheduler also had no data the user saw `status unavailable yet (scheduler accounting not ready)` with exit 0. That message misdirects exactly the scenario the fix for #44 (#48) addressed in `job-output` and `wait` — invoking with a different `--project-dir`/`--config` than at submit time, so run metadata is looked up under the wrong root. This PR deletes the unreachable branch and reports the both-lookups miss the same way as the siblings: `Run not found: <id>` with the conditional project-root hint, exit 1. Closes #47

## Changes

- `src/crewster/cli.py`: delete the unreachable `if not job_id:` branch in `status`; in the `SchedulerError` fallback, report via `_print_run_not_found` and exit 1 when the metadata lookup found no run, keeping the accounting-lag message for known runs.
- `tests/test_cli.py`: pin the new both-lookups-miss report (hint firing and hint suppressed), and set up run metadata in the existing accounting-lag test so it keeps covering the known-run arm.

## Test plan

- New: unknown id with `get_job_detail` returning `[]` or `None` (parametrized over both fallback shapes) and `get_job_status` raising `SchedulerError` → exit 1, `Run not found`, plus the `no runs recorded` hint in a fresh project.
- New: same miss with unrelated run metadata present → hint suppressed.
- Updated: known run with `SchedulerError` → `status unavailable yet`, exit 0, unchanged.
- Scheduler-only lookup for ids the scheduler knows is unchanged and stays pinned by `test_status_unknown_id_does_not_create_runs_dir`.
- `uv run pytest`: 383 passed (baseline on `main`: 380).

## Notes

- With no local run and no scheduler data, a project-root mismatch, a nonexistent id, and accounting lag on a just-submitted raw job id are indistinguishable from the client. This PR reports the metadata miss (exit 1) in all three cases, trading the previously misleading accounting-lag message for consistency with `job-output`/`wait`; the tradeoff is recorded in the code comment at the new branch.
- On real Slurm, a run-id-shaped argument makes `sacct` reject the non-numeric job spec, so an `SSHError` traceback surfaces before this branch is reached; classifying scheduler-side id rejection is tracked in #50.
