### PR TITLE
fix: report scheduler job-id rejection as Run not found in status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/crewster"]
+
+[tool.pytest.ini_options]
+# Make tests/ an explicit import root so helper modules such as
+# tests/rejection_fixtures.py resolve regardless of pytest's import mode
+# (the default prepend mode inserts tests/ implicitly; importlib does not).
+pythonpath = ["tests"]
+testpaths = ["tests"]

--- a/src/crewster/cli.py
+++ b/src/crewster/cli.py
@@ -17,7 +17,7 @@ from .ssh import SSHManager
 from .sync import SyncManager
 from .job import JobManager, JobStatus
 from .run import RunManager
-from .scheduler import JobDetail, SchedulerError
+from .scheduler import JobDetail, JobIdRejectedError, SchedulerError
 
 
 class SchedulerChoice(str, Enum):
@@ -581,31 +581,42 @@ def status(
     ssh = SSHManager(host=hpc_config.cluster.host)
     job_manager = JobManager(ssh_manager=ssh, config=hpc_config)
 
-    details = job_manager.get_job_detail(job_id)
-    if not details:
-        # Scheduler does not support detail (PJM -> None), or sacct has not yet
-        # recorded this job ([] -> no usable row). Fall back to the existing
-        # single-line display. SchedulerError (parse-side absence) becomes a
-        # friendly message; other SSHError (real transport/command failure)
-        # propagates so legitimate failures stay visible to the user.
-        try:
+    # One try covers both scheduler queries so a SchedulerError — parse-side
+    # absence or affirmative id rejection, whichever query it comes from —
+    # is handled at its first observation, without re-querying the scheduler.
+    # Other SSHError (real transport/command failure) propagates so
+    # legitimate failures stay visible to the user.
+    try:
+        details = job_manager.get_job_detail(job_id)
+        if not details:
+            # Scheduler does not support detail (PJM -> None), or sacct has
+            # not yet recorded this job ([] -> no usable row). Fall back to
+            # the single-line display.
             job_status = job_manager.get_job_status(job_id)
-        except SchedulerError:
-            if run is None:
-                # The id failed both lookups: no local run metadata and no
-                # scheduler data. That is indistinguishable from accounting
-                # lag on a raw just-submitted job id, but run metadata lives
-                # under the project root used at submit time, so a wrong
-                # --project-dir/--config produces exactly this double miss.
-                # Report the metadata miss the way job-output/wait do rather
-                # than implying the scheduler knows the job.
-                _print_run_not_found(id, run_manager)
-                raise typer.Exit(1)
-            print(
-                f"Job {job_id}: status unavailable yet (scheduler accounting not ready)"
-            )
+            print(f"Job {job_id}: {job_status.value}")
             return
-        print(f"Job {job_id}: {job_status.value}")
+    except SchedulerError as e:
+        if run is None:
+            # The id failed both lookups: no local run metadata and no
+            # scheduler data (or the scheduler rejected the id outright).
+            # That is indistinguishable from accounting lag on a raw
+            # just-submitted job id, but run metadata lives under the
+            # project root used at submit time, so a wrong
+            # --project-dir/--config produces exactly this double miss.
+            # Report the metadata miss the way job-output/wait do rather
+            # than implying the scheduler knows the job.
+            _print_run_not_found(id, run_manager)
+            raise typer.Exit(1)
+        if isinstance(e, JobIdRejectedError):
+            # Run metadata exists but the scheduler rejects its job id —
+            # deterministic, so "not ready yet" would misdirect: the id
+            # will never become queryable (stale or corrupt metadata).
+            print(
+                f"Job {job_id}: the scheduler rejected this job id"
+                f" (run {run.run_id} metadata may be stale or corrupt)"
+            )
+            raise typer.Exit(1)
+        print(f"Job {job_id}: status unavailable yet (scheduler accounting not ready)")
         return
 
     if len(details) == 1:

--- a/src/crewster/job.py
+++ b/src/crewster/job.py
@@ -6,9 +6,15 @@ from pathlib import Path
 from jinja2 import Template
 
 from .config import HpcConfig, _validate_dq_shell_value
-from .ssh import SSHManager
+from .ssh import CommandResult, SSHError, SSHManager
 from .run import RunConfig
-from .scheduler import JobDetail, JobStatus, SchedulerError, get_scheduler
+from .scheduler import (
+    JobDetail,
+    JobIdRejectedError,
+    JobStatus,
+    SchedulerError,
+    get_scheduler,
+)
 
 
 def _resolve_home_path(ssh_manager, path: str) -> str:
@@ -247,8 +253,39 @@ class JobManager:
         )
         return self.scheduler.parse_job_id(result.stdout)
 
+    def _run_id_query(self, cmd: list[str]) -> CommandResult:
+        """Run a status / detail command whose sole argument of interest is
+        a job id, classifying the scheduler's affirmative id rejection.
+
+        A run-id-shaped argument (``r1``) reaching ``sacct -j`` / ``pjstat``
+        makes the command itself exit non-zero, which ``run_command``
+        surfaces as a plain ``SSHError`` — indistinguishable, by type, from
+        a transport failure. Match the captured stderr against the
+        scheduler's recorded rejection signature and re-raise as
+        ``JobIdRejectedError`` so callers funnel it into the same "no such
+        job" handling as parse-side absence (both are ``SchedulerError``)
+        while still being able to tell the deterministic rejection apart.
+        Anything unrecognized re-raises unchanged (fail-closed), keeping
+        genuine transport failures visible.
+        """
+        try:
+            return self.ssh_manager.run_command(cmd[0], cmd[1:])
+        except SSHError as e:
+            stderr = e.stderr or ""
+            if self.scheduler.is_job_id_rejection(stderr):
+                raise JobIdRejectedError(
+                    f"scheduler rejected the job id: {stderr.strip()}",
+                    stderr=e.stderr,
+                ) from e
+            raise
+
     def get_job_status(self, job_id: str) -> JobStatus:
         """Get job status.
+
+        A scheduler-side rejection of the id itself (non-numeric spec —
+        see ``_run_id_query``) raises ``SchedulerError`` directly; the
+        fallback is not consulted because rejection is deterministic,
+        not absence lag.
 
         On a ``SchedulerError`` from the primary status command (no data
         row — a fresh job not yet indexed, or one aged out of the active
@@ -268,10 +305,9 @@ class JobManager:
         Never returns ``JobStatus.UNKNOWN`` — that terminal interpretation
         belongs to ``wait_for_job`` once its retry budget is exhausted.
         """
-        from .ssh import SSHError
 
         cmd = self.scheduler.status_cmd(job_id)
-        result = self.ssh_manager.run_command(cmd[0], cmd[1:])
+        result = self._run_id_query(cmd)
         try:
             return self.scheduler.parse_status(result.stdout)
         except SchedulerError as primary_absence:
@@ -296,17 +332,17 @@ class JobManager:
         (``detail_cmd`` is ``None`` — e.g. PJM), distinct from ``[]`` which
         means the scheduler is supported but has no usable row yet (sacct
         accounting lag). A multi-element list represents an array job's tasks
-        or a heterogeneous job's components.
+        or a heterogeneous job's components. A scheduler-side rejection of
+        the id itself raises ``SchedulerError`` (see ``_run_id_query``).
         """
         cmd = self.scheduler.detail_cmd(job_id)
         if cmd is None:
             return None
-        result = self.ssh_manager.run_command(cmd[0], cmd[1:])
+        result = self._run_id_query(cmd)
         return self.scheduler.parse_detail(result.stdout)
 
     def get_job_output(self, run_id: str, job_id: str, error: bool = False) -> str:
         """Get job output file contents"""
-        from .ssh import SSHError
 
         workdir = _resolve_home_path(self.ssh_manager, self.config.cluster.workdir)
         run_dir = f"{workdir}/.crewster/runs/{run_id}"
@@ -335,7 +371,6 @@ class JobManager:
         on a missing file. For active or unknown-status jobs, runs `tail -F`
         which retries internally until the output file appears.
         """
-        from .ssh import SSHError
 
         try:
             status = self.get_job_status(job_id)
@@ -380,13 +415,16 @@ class JobManager:
                 unbounded retry on persistently-empty status output — a
                 never-submitted job, or a PJM job aged out of every view.
                 The counter resets on any successful status read, so it
-                does not trip on transient accounting lag. Generic
-                (non-``SchedulerError``) ``SSHError`` does not count and
-                is retried without bound, as before.
+                does not trip on transient accounting lag. A recognized
+                id rejection (``JobIdRejectedError``) is deterministic and
+                returns ``JobStatus.UNKNOWN`` on the first poll without
+                consuming the budget; an *unrecognized* rejection (wording
+                the scheduler's ``is_job_id_rejection`` does not know) is
+                indistinguishable from a transport failure and is retried
+                without bound, like any generic (non-``SchedulerError``)
+                ``SSHError``.
         """
         import time
-
-        from .ssh import SSHError
 
         current_interval = interval
         consecutive_missing = 0
@@ -402,6 +440,11 @@ class JobManager:
 
             try:
                 status = self.get_job_status(job_id)
+            except JobIdRejectedError:
+                # The scheduler rejected the id itself — deterministic, so
+                # further polls can never succeed. Terminate immediately
+                # rather than burning the missing-data budget.
+                return JobStatus.UNKNOWN
             except SchedulerError:
                 # No data row even after any fallback. Bound the retry so
                 # a never-indexed / aged-out job cannot hang the caller

--- a/src/crewster/scheduler.py
+++ b/src/crewster/scheduler.py
@@ -9,16 +9,30 @@ from .ssh import SSHError
 
 
 class SchedulerError(SSHError):
-    """Scheduler returned no usable response.
+    """Scheduler returned no usable response for the requested job id.
 
-    Raised by ``parse_status`` when the scheduler's status command exits
-    cleanly but its output contains no data row from which a ``JobStatus``
-    can be derived — typically a freshly-submitted job that has not yet
-    been indexed by the accounting database (Slurm's ``sacct``) or a job
-    that aged out of the active view (PJM's ``pjstat`` post-``EXT``
-    window). Distinguishing this from a real ``JobStatus.FAILED`` lets
-    callers retry / fall through instead of treating the absence of
-    information as a terminal failure.
+    Two shapes share this type because callers treat them identically —
+    "the scheduler holds no information about this job id":
+
+    - Parse-side absence: raised by ``parse_status`` when the status
+      command exits cleanly but its output contains no data row from
+      which a ``JobStatus`` can be derived — typically a freshly-
+      submitted job that has not yet been indexed by the accounting
+      database (Slurm's ``sacct``) or a job that aged out of the active
+      view (PJM's ``pjstat`` post-``EXT`` window).
+    - Affirmative id rejection: raised by ``JobManager`` when the status
+      / detail command exits non-zero with a stderr matching the
+      scheduler's ``is_job_id_rejection`` signature — e.g. a run-id-
+      shaped argument (``r1``) handed to ``sacct -j`` / ``pjstat``,
+      which both reject non-numeric job specs outright.
+
+    Distinguishing these from a real ``JobStatus.FAILED`` or a transport
+    failure lets callers retry / fall through / report a friendly miss
+    instead of treating the absence of information as a terminal failure.
+
+    The rejection shape is raised as the ``JobIdRejectedError`` subtype so
+    callers that need to distinguish "permanently bad id" from "no data
+    yet" can; catching ``SchedulerError`` covers both.
 
     Inherits from ``SSHError`` so the transient-catch sites in
     ``JobManager`` cover it. ``get_job_status`` catches it to try the
@@ -32,6 +46,19 @@ class SchedulerError(SSHError):
     surfaces that want to discriminate "no data yet" from a real SSH /
     command failure catch ``SchedulerError`` specifically before the
     generic ``SSHError``.
+    """
+
+
+class JobIdRejectedError(SchedulerError):
+    """The scheduler affirmatively rejected the job-id argument itself.
+
+    Unlike parse-side absence (the plain ``SchedulerError`` shape),
+    rejection is deterministic: retrying or consulting a fallback view can
+    never succeed for this id. Callers use the distinction to terminate
+    immediately (``wait_for_job`` skips its missing-data budget) and to
+    report an invalid id rather than accounting lag (``status`` for a
+    known run). Callers that only need "no such job" semantics keep
+    catching ``SchedulerError``, which covers this subtype.
     """
 
 
@@ -131,6 +158,18 @@ class Scheduler(ABC):
         differing column layout cannot be misread as a real status."""
         return None
 
+    def is_job_id_rejection(self, stderr: str) -> bool:
+        """Whether ``stderr`` from a failed status / detail command is this
+        scheduler's signature for "the job-id argument itself was rejected"
+        (e.g. a non-numeric spec), as opposed to a transport or service
+        failure.
+
+        Fail-closed: the default recognizes nothing, and implementations
+        match only recorded signatures, so an unrecognized failure keeps
+        propagating as a plain ``SSHError`` rather than being misreported
+        as job absence."""
+        return False
+
     @abstractmethod
     def output_directives(self, run_dir: str) -> list[str]:
         """Bookkeeping directives that route the job's stdout/stderr under
@@ -178,6 +217,18 @@ class Slurm(Scheduler):
 
     def submit_cmd(self) -> list[str]:
         return ["sbatch", "--parsable"]
+
+    def is_job_id_rejection(self, stderr: str) -> bool:
+        # Recorded on slurm 23.02.6: `sacct -j r1 ...` exits 1 with
+        # `sacct: fatal: Bad job/step specified: r1` on stderr, for both
+        # the status_cmd and detail_cmd formats. A numeric but nonexistent
+        # id exits 0 with no rows instead (parse-side absence). Matched
+        # per line and with the `fatal:` prefix so a stray mention of the
+        # phrase inside an otherwise-transient multi-line stderr (site
+        # wrappers, mixed diagnostics) fails closed as a plain SSHError.
+        return any(
+            "fatal: Bad job/step specified" in line for line in stderr.splitlines()
+        )
 
     def parse_job_id(self, output: str) -> str:
         return output.strip()
@@ -371,6 +422,20 @@ class PJM(Scheduler):
 
     def submit_cmd(self) -> list[str]:
         return ["pjsub"]
+
+    def is_job_id_rejection(self, stderr: str) -> bool:
+        # Recorded on Fugaku: `pjstat -v --choose jid,st,ec,sn r1` exits 1
+        # with `[ERR.] PJM 0211 pjstat Invalid jobid: r1.` on stderr,
+        # identically for the -H history view. A numeric but nonexistent
+        # id exits 0. Both the message code and the phrase must match on
+        # the same line so wording drift on another deployment fails
+        # closed (plain SSHError) rather than misclassifying an unrelated
+        # 0211-coded failure — or a multi-line stderr whose lines each
+        # carry only one of the two markers.
+        return any(
+            "PJM 0211" in line and "Invalid jobid" in line
+            for line in stderr.splitlines()
+        )
 
     def parse_job_id(self, output: str) -> str:
         # pjsub output example: "[INFO] PJM 0000 pjsub Job XXXXXXXX submitted."

--- a/src/crewster/ssh.py
+++ b/src/crewster/ssh.py
@@ -9,9 +9,18 @@ from typing import Optional
 
 
 class SSHError(Exception):
-    """SSH operation error"""
+    """SSH operation error.
 
-    pass
+    ``stderr`` carries the remote command's captured stderr separately from
+    the human-readable message so callers can classify the failure (e.g. a
+    scheduler's job-id rejection signature) without parsing the message
+    string, whose format is a display concern. ``None`` when the failure
+    had no captured stderr (or the raise site predates capture).
+    """
+
+    def __init__(self, message: str, *, stderr: str | None = None):
+        super().__init__(message)
+        self.stderr = stderr
 
 
 @dataclass
@@ -131,7 +140,7 @@ class SSHManager:
                 parts.append(f"stdout:\n{result.stdout.rstrip()}")
             if result.stderr:
                 parts.append(f"stderr:\n{result.stderr.rstrip()}")
-            raise SSHError("\n".join(parts))
+            raise SSHError("\n".join(parts), stderr=result.stderr)
 
         return CommandResult(
             returncode=result.returncode,

--- a/src/crewster/ssh.py
+++ b/src/crewster/ssh.py
@@ -140,7 +140,9 @@ class SSHManager:
                 parts.append(f"stdout:\n{result.stdout.rstrip()}")
             if result.stderr:
                 parts.append(f"stderr:\n{result.stderr.rstrip()}")
-            raise SSHError("\n".join(parts), stderr=result.stderr)
+            # Empty stderr is normalized to None so the field stays a
+            # reliable "no captured stderr" sentinel per the class docstring.
+            raise SSHError("\n".join(parts), stderr=result.stderr or None)
 
         return CommandResult(
             returncode=result.returncode,

--- a/tests/rejection_fixtures.py
+++ b/tests/rejection_fixtures.py
@@ -1,0 +1,24 @@
+"""Shared job-id rejection fixtures.
+
+Verbatim rejection stderr recorded on real clusters
+(https://github.com/ultimatile/crewster/issues/50): slurm 23.02.6 on
+HOKUSAI BW2 and PJM on Fugaku. Single source for every suite that pins
+the classifier or replays the rejection, so a signature update cannot
+leave a stale copy silently certifying a match the production matcher
+no longer performs.
+
+A plain helper module (not conftest.py) so the constants stay importable
+at collection time — parametrize needs them — without importing the
+pytest plugin module.
+"""
+
+from crewster.ssh import SSHError
+
+SACCT_ID_REJECTION_STDERR = "sacct: fatal: Bad job/step specified: r1\n"
+PJSTAT_ID_REJECTION_STDERR = "[ERR.] PJM 0211 pjstat Invalid jobid: r1.\n"
+
+
+def make_ssh_failure(stderr: str, cmd: str = "sacct -j r1") -> SSHError:
+    """Build the SSHError that run_command raises for a non-zero remote exit,
+    shaped like the real raise site (message + structured stderr)."""
+    return SSHError(f"SSH command failed (exit 1): {cmd}", stderr=stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,12 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from crewster.main import app
+
+from rejection_fixtures import (
+    PJSTAT_ID_REJECTION_STDERR,
+    SACCT_ID_REJECTION_STDERR,
+    make_ssh_failure,
+)
 from crewster import cli  # noqa: F401 - register commands
 
 
@@ -454,6 +460,87 @@ def test_status_unknown_id_with_existing_runs_omits_root_hint(
     assert result.exit_code == 1
     assert "Run not found: unknown-id" in result.stdout
     assert "no runs recorded" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("scheduler", "rejection_stderr"),
+    [
+        ("slurm", SACCT_ID_REJECTION_STDERR),
+        ("pjm", PJSTAT_ID_REJECTION_STDERR),
+    ],
+)
+def test_status_scheduler_rejected_id_reports_run_not_found(
+    cli_runner, temp_dir, monkeypatch, scheduler, rejection_stderr
+):
+    """A run-id-shaped argument with no local metadata reaches the scheduler,
+    which rejects the non-numeric id with a non-zero exit
+    (https://github.com/ultimatile/crewster/issues/50). That rejection must
+    funnel into the same Run-not-found report as a numeric double miss — from
+    a single scheduler query, not a classify-then-requery replay — and not
+    escape as an SSHError traceback. Mocks at the SSHManager layer with the
+    stderr recorded on real clusters — JobManager-level mocks replace the
+    error-raising layer entirely and cannot pin this path."""
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init", "--scheduler", scheduler])
+
+    calls: list[str] = []
+
+    def reject(self, cmd, args=None, input_text=None):
+        calls.append(cmd)
+        raise make_ssh_failure(rejection_stderr, cmd=cmd)
+
+    with patch("crewster.ssh.SSHManager.run_command", reject):
+        result = cli_runner.invoke(app, ["status", "r1"])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "Run not found: r1" in result.stdout
+    assert "no runs recorded" in result.stdout
+    # The rejection is classified at its first observation; a second SSH
+    # round-trip would both waste time and risk a transport flake turning
+    # an already-classified rejection back into a traceback.
+    assert len(calls) == 1
+
+
+def test_status_known_run_with_rejected_job_id_reports_rejection(
+    cli_runner, temp_dir, monkeypatch
+):
+    """When run metadata exists but its recorded job id is rejected by the
+    scheduler (stale or corrupt metadata), the deterministic rejection must
+    not masquerade as transient accounting lag — the user would retry
+    forever. Report the rejection and exit non-zero."""
+    monkeypatch.chdir(temp_dir)
+    _setup_run_meta(temp_dir)
+
+    def reject(self, cmd, args=None, input_text=None):
+        raise make_ssh_failure(SACCT_ID_REJECTION_STDERR, cmd=cmd)
+
+    with patch("crewster.ssh.SSHManager.run_command", reject):
+        result = cli_runner.invoke(app, ["status", "r1"])
+
+    assert result.exit_code == 1
+    assert "rejected this job id" in result.stdout
+    assert "status unavailable yet" not in result.stdout
+
+
+def test_status_transport_failure_still_raises(cli_runner, temp_dir, monkeypatch):
+    """A non-rejection SSH failure (transport outage) must stay visible as an
+    SSHError rather than being misreported as a missing run."""
+    from crewster.ssh import SSHError
+
+    monkeypatch.chdir(temp_dir)
+    cli_runner.invoke(app, ["init"])
+
+    def outage(self, cmd, args=None, input_text=None):
+        raise SSHError(
+            f"SSH command failed (exit 255): {cmd}",
+            stderr="ssh: connect to host cluster port 22: Connection refused\n",
+        )
+
+    with patch("crewster.ssh.SSHManager.run_command", outage):
+        result = cli_runner.invoke(app, ["status", "r1"])
+
+    assert isinstance(result.exception, SSHError)
 
 
 def test_status_normalizes_decorated_cancelled_state(cli_runner, temp_dir, monkeypatch):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -6,9 +6,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from crewster.job import JobManager, JobStatus, _extract_prologue_directives
-from crewster.scheduler import JobDetail, SchedulerError
+from crewster.scheduler import JobDetail, JobIdRejectedError, SchedulerError
 from crewster.ssh import SSHManager, SSHError
 from crewster.config import HpcConfig, ClusterConfig, EnvConfig, SlurmConfig, PjmConfig
+
+from rejection_fixtures import (
+    PJSTAT_ID_REJECTION_STDERR,
+    SACCT_ID_REJECTION_STDERR,
+    make_ssh_failure,
+)
 
 
 @pytest.fixture
@@ -385,6 +391,105 @@ class TestJobManagerStatus:
         with pytest.raises(SchedulerError):
             manager.get_job_status("12345678")
         assert mock_ssh_manager.run_command.call_count == 2
+
+
+class TestJobManagerIdRejection:
+    """Scheduler-side rejection of the job-id argument itself
+    (https://github.com/ultimatile/crewster/issues/50).
+
+    stderr fixtures are the verbatim rejections recorded on real clusters.
+    Classification must be signature-matched: a generic SSHError (transport
+    failure) keeps propagating unchanged so wait_for_job's unbounded
+    transient retry and the CLI's failure visibility are preserved."""
+
+    def test_get_job_status_slurm_rejection_raises_rejected_error(
+        self, mock_ssh_manager, sample_config
+    ):
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = make_ssh_failure(
+            SACCT_ID_REJECTION_STDERR
+        )
+
+        with pytest.raises(JobIdRejectedError) as exc_info:
+            manager.get_job_status("r1")
+        # The structured stderr travels with the classified error so
+        # callers keep the scheduler's diagnostic without message parsing.
+        assert exc_info.value.stderr == SACCT_ID_REJECTION_STDERR
+
+    def test_get_job_status_pjm_rejection_skips_history_fallback(
+        self, mock_ssh_manager, pjm_config
+    ):
+        # Rejection is deterministic (the id itself is bad), not absence
+        # lag, so the -H history view must not be consulted: it would
+        # reject the same id with the same error.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=pjm_config)
+        mock_ssh_manager.run_command.side_effect = make_ssh_failure(
+            PJSTAT_ID_REJECTION_STDERR, cmd="pjstat r1"
+        )
+
+        with pytest.raises(JobIdRejectedError):
+            manager.get_job_status("r1")
+        assert mock_ssh_manager.run_command.call_count == 1
+
+    def test_get_job_detail_slurm_rejection_raises_rejected_error(
+        self, mock_ssh_manager, sample_config
+    ):
+        # On Slurm the detail command runs before any status query in the
+        # CLI status path, so it is the first place a rejected id lands.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = make_ssh_failure(
+            SACCT_ID_REJECTION_STDERR
+        )
+
+        with pytest.raises(JobIdRejectedError):
+            manager.get_job_detail("r1")
+
+    def test_wait_for_job_terminates_immediately_on_rejection(
+        self, mock_ssh_manager, sample_config, monkeypatch
+    ):
+        # A recognized rejection is deterministic, so wait_for_job must
+        # return UNKNOWN on the first poll instead of burning the
+        # max_missing_polls budget (10 polls with adaptive backoff).
+        import time
+
+        monkeypatch.setattr(time, "sleep", lambda _: None)
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = make_ssh_failure(
+            SACCT_ID_REJECTION_STDERR
+        )
+
+        status = manager.wait_for_job("r1", interval=0)
+        assert status == JobStatus.UNKNOWN
+        assert mock_ssh_manager.run_command.call_count == 1
+
+    @pytest.mark.parametrize("method", ["get_job_status", "get_job_detail"])
+    def test_non_matching_ssherror_propagates_unchanged(
+        self, mock_ssh_manager, sample_config, method
+    ):
+        # A transport failure must stay a plain SSHError: reclassifying it
+        # would misreport an outage as job absence.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        original = SSHError(
+            "SSH command failed (exit 255): sacct -j 12345",
+            stderr="ssh: connect to host cluster port 22: Connection refused\n",
+        )
+        mock_ssh_manager.run_command.side_effect = original
+
+        with pytest.raises(SSHError) as exc_info:
+            getattr(manager, method)("12345")
+        assert exc_info.value is original
+        assert not isinstance(exc_info.value, SchedulerError)
+
+    def test_ssherror_without_stderr_propagates_unchanged(
+        self, mock_ssh_manager, sample_config
+    ):
+        # SSHError.stderr defaults to None; classification must tolerate it.
+        manager = JobManager(ssh_manager=mock_ssh_manager, config=sample_config)
+        mock_ssh_manager.run_command.side_effect = SSHError("boom")
+
+        with pytest.raises(SSHError) as exc_info:
+            manager.get_job_status("12345")
+        assert not isinstance(exc_info.value, SchedulerError)
 
 
 class TestJobManagerDetail:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,6 +5,8 @@ import pytest
 from crewster.scheduler import PJM, JobDetail, JobStatus, SchedulerError, Slurm
 from crewster.ssh import SSHError
 
+from rejection_fixtures import PJSTAT_ID_REJECTION_STDERR, SACCT_ID_REJECTION_STDERR
+
 
 class TestSlurmStatusCmd:
     def test_status_cmd_includes_X_flag(self):
@@ -297,6 +299,62 @@ class TestSchedulerErrorInheritance:
         # handling. SchedulerError must inherit so those existing
         # handlers cover it without modification.
         assert issubclass(SchedulerError, SSHError)
+
+
+class TestIsJobIdRejection:
+    """Signature matching for scheduler-side job-id rejection
+    (https://github.com/ultimatile/crewster/issues/50).
+
+    Positive fixtures are the verbatim stderr recorded on real clusters
+    (slurm 23.02.6 / Fugaku PJM) for a run-id-shaped argument passed as a
+    job id. Matching must stay fail-closed: anything unrecognized keeps
+    propagating as a plain SSHError, so transport failures are never
+    misreported as job absence."""
+
+    def test_slurm_matches_recorded_sacct_rejection(self):
+        assert Slurm().is_job_id_rejection(SACCT_ID_REJECTION_STDERR)
+
+    def test_pjm_matches_recorded_pjstat_rejection(self):
+        assert PJM().is_job_id_rejection(PJSTAT_ID_REJECTION_STDERR)
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "",
+            "ssh: connect to host cluster port 22: Connection refused",
+            "sacct: error: slurmdbd: Connection refused",
+            # The phrase without sacct's `fatal:` prefix (e.g. echoed by a
+            # site wrapper inside otherwise-transient diagnostics) must not
+            # classify as rejection.
+            "wrapper: Bad job/step specified mentioned in prior run\n"
+            "ssh: connection reset\n",
+        ],
+        ids=["empty", "transport", "slurmdbd-outage", "phrase-no-prefix"],
+    )
+    def test_slurm_rejects_unrelated_stderr(self, stderr):
+        assert not Slurm().is_job_id_rejection(stderr)
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "",
+            "ssh: connect to host fugaku port 22: Connection refused",
+            # Same message code with different wording, and the phrase
+            # without the code: each alone must not match (fail-closed
+            # against wording drift / unrelated 0211-coded failures).
+            "[ERR.] PJM 0211 pjstat some other failure.",
+            "pjstat Invalid jobid: r1.",
+            # Both markers present but on different lines: matching is
+            # per-line, so a multi-line stderr mixing an unrelated
+            # 0211-coded failure with a stray "Invalid jobid" mention
+            # must not classify as rejection.
+            "[ERR.] PJM 0211 pjstat some other failure.\n"
+            "wrapper: Invalid jobid mentioned elsewhere\n",
+        ],
+        ids=["empty", "transport", "code-only", "phrase-only", "split-lines"],
+    )
+    def test_pjm_rejects_unrelated_stderr(self, stderr):
+        assert not PJM().is_job_id_rejection(stderr)
 
 
 class TestPJMParseJobID:

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -6,6 +6,8 @@ import pytest
 
 from crewster.ssh import SSHManager, SSHError
 
+from rejection_fixtures import SACCT_ID_REJECTION_STDERR
+
 
 class TestSSHManagerInit:
     def test_init_with_host(self):
@@ -142,6 +144,26 @@ class TestSSHManagerRunCommand:
             msg = str(exc_info.value)
             assert "stdout:\npartial output" in msg
             assert "stderr:\nwarning then error" in msg
+
+    def test_run_command_failure_carries_structured_stderr(self):
+        # The raised SSHError exposes the remote stderr as a field so
+        # callers (JobManager's id-rejection classification) can match
+        # scheduler signatures without parsing the display message.
+        manager = SSHManager(host="myhpc")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr=SACCT_ID_REJECTION_STDERR,
+            )
+            with pytest.raises(SSHError) as exc_info:
+                manager.run_command("sacct", ["-j", "r1"])
+            assert exc_info.value.stderr == SACCT_ID_REJECTION_STDERR
+
+    def test_ssherror_stderr_defaults_to_none(self):
+        # Raise sites that predate stderr capture (or have none) must
+        # still construct with the message alone.
+        assert SSHError("boom").stderr is None
 
     def test_run_command_failure_with_empty_streams_keeps_command_and_code(self):
         # Boundary case: command failed but produced no output. The

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -176,6 +176,9 @@ class TestSSHManagerRunCommand:
                 manager.run_command("hostname")
             msg = str(exc_info.value)
             assert msg == "SSH command failed (exit 255): hostname"
+            # Empty stderr normalizes to None so the field stays a reliable
+            # "no captured stderr" sentinel.
+            assert exc_info.value.stderr is None
 
     def test_run_command_captures_stderr(self):
         manager = SSHManager(host="myhpc")


### PR DESCRIPTION
## Summary

On Slurm, `crewster status r1` — a run-id-shaped argument invoked from a different project root than at submit time — died with an SSHError traceback instead of the `Run not found` report added for #47: `sacct` rejects a non-numeric job spec with a non-zero exit (`sacct: fatal: Bad job/step specified: r1`, observed on slurm 23.02.6), and the failure escaped uncaught from the detail query, which runs before the status query the issue originally described. PJM has the same bug via `pjstat` (`[ERR.] PJM 0211 pjstat Invalid jobid: r1.`, observed on Fugaku, identical for the `-H` history view). This PR classifies the scheduler's affirmative id rejection in the scheduler layer so it funnels into the same `Run not found` report an unknown numeric id already gets, while transport failures stay loudly visible. Closes #50.

## Changes

- `src/crewster/ssh.py` — `SSHError` carries the remote stderr as a structured `stderr` field, populated by `run_command` (message format unchanged).
- `src/crewster/scheduler.py` — new `Scheduler.is_job_id_rejection(stderr)` hook, default `False`; Slurm and PJM match their recorded rejection signatures per line, fail-closed (unrecognized stderr keeps propagating as a plain `SSHError`). New `JobIdRejectedError(SchedulerError)` subtype distinguishes deterministic rejection from the existing absence case, where the status command exits 0 but its output has no data row for the job.
- `src/crewster/job.py` — `_run_id_query` wraps the status / detail queries and re-raises a matched rejection as `JobIdRejectedError`; the PJM history fallback is skipped for rejections (deterministic, not absence lag). `wait_for_job` returns `UNKNOWN` on the first poll for a rejection instead of burning the `max_missing_polls` budget.
- `src/crewster/cli.py` — `status` handles `SchedulerError` from both queries at one classification point: an unknown id gets the `Run not found` report (exit 1), and a known run whose recorded job id is rejected is reported as stale / corrupt metadata (exit 1) instead of the `status unavailable yet (scheduler accounting not ready)` message, which would misdirect the user into waiting for a permanently invalid id.

## Impact

`get_job_status` / `get_job_detail` now raise `SchedulerError` (the `JobIdRejectedError` subtype) where a plain `SSHError` previously propagated, but only for stderr matching a recorded rejection signature. All existing `except SSHError` sites (the file-existence check in `get_job_output`, `tail_job_output`'s pre-tail status check) cover the subtype unchanged; `wait_for_job`'s unbounded transient retry for generic `SSHError` is preserved.

## Test plan

- `tests/test_scheduler.py`: classifier accepts the recorded real-cluster stderr fixtures and fails closed on transport errors, empty stderr, code-only / phrase-only / split-line variants.
- `tests/test_job.py`: rejection → `JobIdRejectedError` (both schedulers), structured stderr carried, PJM fallback skipped, non-matching `SSHError` propagates unchanged, `wait_for_job` terminates on the first poll.
- `tests/test_cli.py`: regression tests mock at the `SSHManager` layer — the CLI status tests added for #47 mock `JobManager` wholesale, which replaces the error-raising layer and is how this gap survived them: `status r1` → exit 1 + `Run not found: r1` from a single scheduler query, on both schedulers; known-run rejection reported distinctly; transport failure still raises.
- Recorded signatures live in `tests/rejection_fixtures.py` as the single source for all suites.
- `uv run pytest`: 407 passed. Verified end-to-end against real clusters (Slurm and PJM): `crewster status r1` from a fresh project root prints the `Run not found` report with exit 1 and no traceback.

## Notes

- Signature matching is deployment-recorded (slurm 23.02.6, Fugaku PJM). On a deployment with different rejection wording the classifier fails closed: the pre-existing `SSHError` traceback behavior returns, and the signature list needs extending.
- `wait` / `submit --wait` still report a rejected recorded job id as `UNKNOWN`, and `job-output --follow` hangs on `tail -F` — reachable only with stale or corrupt run metadata. Extending the distinct rejection report to those commands is tracked in #52.

@coderabbitai ignore
